### PR TITLE
[240122] BOJ 2839 설탕배달 - 1문제

### DIFF
--- a/seoyoung059/Week_01/BOJ_2839.java
+++ b/seoyoung059/Week_01/BOJ_2839.java
@@ -1,0 +1,65 @@
+// 백준 2839 설탕 배달
+
+package seoyoung059.Week01;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+public class BOJ_2839 {
+
+  
+    private static void solution (int n) {
+        int[] arr = new int[n+1];
+        for (int i = 3; i <= n; i++) {
+            arr[i]=-1;
+            if (i==3||i==5) arr[i]=1;
+            else if (i>5) {
+                if (arr[i - 5] > 0 && arr[i - 3] > 0)
+                    arr[i] = Math.min(arr[i - 5], arr[i - 3]) + 1;
+                else if (arr[i - 5] > 0) arr[i] = arr[i - 5] + 1;
+                else if (arr[i - 3] > 0) arr[i] = arr[i - 3] + 1;
+            }
+        }
+        if (arr[n]>0)
+            System.out.println(arr[n]);
+        else System.out.println(-1);
+    }
+
+    
+    private static int solution2(int n) {
+        int a = n/5;
+        int b = n%5;
+        while (a > -1){
+            if (b%3==0)
+                return a+b/3;
+            else {
+                a--;
+                b += 5;
+            }
+        }
+        return -1;
+    }
+
+    private static int solution3(int n) {
+        int num = 0;
+        while (n>-1) {
+            if (n%5!=0){
+                n-=3;
+                num++;
+            } else {
+                num+=n/5;
+                return num;
+            }
+        }
+        return -1;
+    }
+
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+//        solution(n);
+//        System.out.println(solution2(n));
+        System.out.println(solution3(n));
+    }
+}


### PR DESCRIPTION
[solution 1] DP
Nkg의 설탕을 배달하기 위해서는 (N-3)kg에서 3kg 봉지 하나를 더한 경우와 (N-5)kg에서 5kg 봉지 하나를 더한 경우가 있으므로, 0kg부터 Nkg까지의 경우를 이전 경우를 참고하여 차례로 구할 수 있다.

0kg부터 Nkg의 경우에 대해 구할 것이므로, N+1 크기의 int 배열 arr를 생성한다. 이렇게 하면 배열의 i번째 인덱스에는 ikg을 배달할떄 봉지의 최소 개수를 넣을 수 있다.

3kg과 5kg의 봉지가 있으므로, arr[3]부터 반복문을 시작하고, arr[3]과 arr[5]를 각각 1개로 초기화한다.
arr[i]에 대해서 구할 때 (i-3)kg와 (i-5)kg의 경우 모두 배달할 수 있는 방법이 있다면, 즉, arr[i-3]과 arr[i-5] 두 값이 모두 0보다 크다면, 그 중 작은 값 + 1의 봉지 수로 배달할 수 있다.
그 외에는 arr[i-3]>0이면 arr[i] = arr[i-3]+1이고, arr[i-5]>0이면 arr[i] = arr[i-5]+1이다.
그 외 arr[i-3]과 arr[i-5] 경우가 모두 -1로 배달할 수 없는 경우라면, arr[i] 또한 정확히 ikg을 배달할 수 없는 경우이므로 arr[i]=-1이다.

[solution 2, 3] 수학, Greedy
같은 무게를 배달할 때, 5kg의 봉지가 많을 수록 더 적은 봉지의 수로 Nkg을 배달할 수 있다.(Greedy 방식) 따라서, 최대한 많은 무게를 5kg봉지로 배달한 후, 남는 무게가 3kg으로 나누어떨어지는지 확인하여, 가능하면 그것이 배달하는 봉지의 최소 개수이고, 불가능하다면 5kg봉지를 남는 무게에 추가하여 이것이 다시 3kg으로 나누어떨어지는지 확인하는 방식으로 계산할 수 있다.