### PR TITLE
[240124] BOJ 4485 녹색 옷 입은 애가 젤다지? - 1문제

### DIFF
--- a/u1qns/Week_01/BOJ_4485_녹색 옷 입은 애가 젤다지?
+++ b/u1qns/Week_01/BOJ_4485_녹색 옷 입은 애가 젤다지?
@@ -32,7 +32,6 @@ struct cmp
 void solve()
 {
 	std::priority_queue<T, std::vector<T>, cmp> pq;
-
 	pq.push({{0, 0}, map[0][0]});
 	visited[0][0] = true;
 

--- a/u1qns/Week_01/BOJ_4485_녹색 옷 입은 애가 젤다지?
+++ b/u1qns/Week_01/BOJ_4485_녹색 옷 입은 애가 젤다지?
@@ -1,0 +1,86 @@
+#include <iostream>
+#include <memory.h>
+#include <queue>
+#include <algorithm>
+#include <vector>
+
+typedef std::pair<int, int> pii;
+typedef std::pair<pii, int> T;
+
+const int SIZE = 125 + 1;
+int N, answer = 0;
+int map[SIZE][SIZE] = {0, };
+bool visited[SIZE][SIZE] = {false, };
+
+const int dx[4] = {0, 0, 1, -1};
+const int dy[4] = {1, -1, 0, 0};
+bool isValid(const int x, const int y)
+{
+	if(x<0 || y<0 || x>=N || y>=N)
+		return false;
+	return true;
+}
+
+struct cmp
+{
+	bool operator()(const T& a, const T& b)
+	{
+		return a.second > b.second;
+	}
+};
+
+void solve()
+{
+	std::priority_queue<T, std::vector<T>, cmp> pq;
+
+	pq.push({{0, 0}, map[0][0]});
+	visited[0][0] = true;
+
+	while(!pq.empty())
+	{
+		int _x = pq.top().first.first;
+		int _y = pq.top().first.second;
+		int _v = pq.top().second;
+		pq.pop();
+
+		for(int d=0; d<4; ++d)
+		{
+			int x = _x + dx[d];
+			int y = _y + dy[d];
+
+			if(!isValid(x, y) || visited[x][y])
+				continue;
+
+			if(x == N-1 && y == N-1)
+			{
+				answer = _v + map[x][y];
+				return;
+			}
+
+			pq.push({{x, y}, _v + map[x][y]});
+			visited[x][y] = true;
+		}
+	}
+}
+
+int main()
+{
+	for(int tc=1; ;++tc)
+	{
+		std::cin >> N;
+		if(N == 0) break;
+		
+		memset(visited, false, sizeof(visited));
+		for(int i=0; i<N; ++i)
+		{
+			for(int j=0; j<N; ++j)
+				std::cin >> map[i][j];
+		}
+
+		solve();
+
+		std::printf("Problem %d: %d\n", tc, answer);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
문제 요약 : (0, 0) 좌표에서 (N-1, N-1)로 이동하는데 최소 비용 거리를 구하시오.
--

**<DFS를 재귀함수로 풀 수 있지만 우선순위큐를 이용한 이유>**
호출 스택이 많이 쌓이면 메모리 초과가 날 수 있기 때문에 지양하였습니다.

pq에서 정렬 기준을 오름차순으로 커스텀 정렬해주면 최소 비용 위치 꺼내어 경로를 찾기 때문에 가장 먼저 도착지에 도달하면 그 값이 최소값이 됩니다. 이러한 특성이 이용해 재방문여부를 체크하여 가지치기를 하였습니다. 
또한, 재귀함수를 사용할시 필요한 DP를 피하여 메모리를 줄일 수 있습니다.
- DP배열 용도 : 특정 위치에서의 최소 비용 거리를 저장


