### PR TITLE
[240125] BOJ 2023 신기한 소수

### DIFF
--- a/seoyoung059/Week_01/BOJ_2023.java
+++ b/seoyoung059/Week_01/BOJ_2023.java
@@ -1,0 +1,45 @@
+package seoyoung059.Week_01;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class BOJ_2023 {
+    private static  StringBuilder sb = new StringBuilder();
+    private static boolean isPrime(int n) {
+        for (int i = 2; i*i<=n; i++) {
+            if (n%i==0) return false;
+        }
+        return true;
+    }
+    private static void solution(int n) {
+        Queue<Integer> q = new LinkedList<>();
+        for (int i = 2; i < 10; i++) {
+            if (isPrime(i)) q.offer(i);
+        }
+        int curr; int tmp;
+        while(!q.isEmpty()){
+            curr = q.poll();
+            if((Integer.toString(curr)).length()==n) {
+                sb.append(curr);
+                sb.append("\n");
+                continue;
+            }
+            for (int i = 0; i < 5; i++) {
+                tmp=10*curr+i*2-1;
+                if(Integer.toString(tmp).length()<=n && isPrime(tmp)) {
+                    q.offer(tmp);
+                }
+            }
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        
+        solution(n);
+        System.out.println(sb.toString());
+    }
+}


### PR DESCRIPTION
### 소요 시간
약 40분
### 생각의 흐름
- 1≤N≤8 → 무작정 소수 여부를 확인하기엔 범위가 너무 많다! 확인해야하는 수를 줄여야.
- 왼쪽부터 한자리도 소수 → 그렇다면 한자리부터 시작해서 자리수를 늘려 나가는 방향으로 구해가면 경우의 수를 훨씬 줄일 수 있지 않을까?
    - 한 자리수부터(2~9) 소수인지 확인하여 소수이면 큐에 넣음
    - 큐에서 꺼낸 k자리수의 신비한 소수에 10을 곱하고 한자리수 홀수를 더한 값이 소수인지 확인하면 소수 하나당 5번씩만 확인해서 (k+1)자리수의 신비한 소수를 만들 수 있다.
### 풀이
- 소수 판별 알고리즘 기억 안남 → 처음엔 그냥 2부터 n/2까지 나눠서 나눠떨어지면 false return ⇒ 풀리긴 했지만 속도 느림
- 후에 다시 알고리즘 찾아보고 수정
    ⇒i=2부터 i*i≤n까지 확인하면 된다 (속도 약 6배 차이)
![image](https://github.com/BE-Archive/Algorithm-Study/assets/58359639/adf572a0-6960-4c84-9d16-13766c1e6881)
