### PR TITLE
[240129] BOJ 1967 트리의 지름

### DIFF
--- a/u1qns/BOJ_1967_트리의 지름.cpp
+++ b/u1qns/BOJ_1967_트리의 지름.cpp
@@ -1,0 +1,54 @@
+#include <iostream>
+const int MAX = 100000 + 1;
+bool visited[MAX] = {false, };
+
+int N, answer = 0;
+struct Info
+{
+    int dir[2];
+    int sum[2];
+
+    void setValue(const int d, const int v, const boolean b)
+    {
+        dir[b] = d;
+        sum[b] = v;
+    }
+} node [MAX];
+
+int solve(const int idx, bool d)
+{
+    if(node[idx].dir[d] == 0)
+        return node[idx].dir[d];
+
+    if(visited[idx]) return node[idx].dir[d];
+    visited[idx] = true;
+    node[idx].sum[d] += solve(node[idx].dir[d], d);
+    node[idx].sum[!d] += solve(node[idx].dir[!d], !d);
+    return node[idx].sum[d];
+}
+
+int main()
+{
+    std::cin >> N;
+    int p, c, v;
+    bool isLeft = true;
+    for(int i=1; i<N; ++i)
+    {
+        std::cin >> p >> c >> v;
+
+        if(node[p].dir[0] == 0) node[p].setRight(c, v, 1);
+        else node[p].setRight(c, v, 0);
+    }
+
+    solve(1, 0);
+    solve(1, 1);
+    for(int i=1; i<=N; ++i)
+    {
+        int tmp = node[i].sum[0] + node[i].sum[1];
+        answer = (answer > tmp ? answer : tmp);
+    }
+    std::cout << answer;
+
+
+    return 0;
+}


### PR DESCRIPTION
**👎 틀린 이유**

이진 트리로 착각 => _!! 문제를 잘 읽자 !!_

**👍  올바른 접근법 by 갓병익**
먼저 이진트리가 아니라는 점에 유의해야 한다. 
즉, **자식 노드가 2개 이상 올 수 있다**.

이러한 이유로 내가 작성한 오른쪽, 왼쪽의 경로 가중치를 구하는 논리는 맞지 않는다는 걸 깨달을 수 있었다.
재귀함수를 응용해 이 문제를 해결할 수 있다. 

1. 함수의 역할 : 자식 노드 2개의 가중치 합산을 구하는 메서드
2. 파라미터 n : 부모 노드의 인덱스
3. 기저조건 : 자식 노드가 없으면 더 이상 재귀호출을 하지 않는다. 
