### PR TITLE
[240129] BOJ 1967 트리의 지름

### DIFF
--- a/seoyoung059/Week_02/BOJ_1967.java
+++ b/seoyoung059/Week_02/BOJ_1967.java
@@ -1,0 +1,69 @@
+package seoyoung059.Week_02;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+public class BOJ_1967 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static TreeNode[] arr;
+    static TreeNode root;
+    static LinkedList[] childArray;
+    static int answer;
+    static class TreeNode {
+        int num;
+        int parent;
+        int weight;
+
+
+        public TreeNode(int num, int parent, int weight){
+            this.num = num;
+            this.parent = parent;
+            this.weight = weight;
+        }
+
+    }
+
+    static int dfs(int currNode) {
+        if (childArray[currNode].isEmpty())
+            return arr[currNode].weight;
+        int max = 0;
+        int tmp=0;
+        for (Object n: childArray[currNode]) {
+            tmp = dfs((int)n);
+            answer = Math.max(tmp+max, answer);
+            max = Math.max(max, tmp);
+        }
+        return max + arr[currNode].weight;
+
+    }
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        arr = new TreeNode[n+1];
+        root = new TreeNode(1,0, 0);
+        arr[1] = root;
+        childArray = new LinkedList[n+1];
+        for (int i = 1; i < n+1; i++) {
+            childArray[i] = new LinkedList<Integer>();
+        }
+        int parent; int curr; int weight;
+
+        for (int i = 2; i < n+1; i++) {
+            st = new StringTokenizer(br.readLine());
+            parent = Integer.parseInt(st.nextToken());
+            curr = Integer.parseInt(st.nextToken());
+            weight = Integer.parseInt(st.nextToken());
+
+            arr[curr] = new TreeNode(curr,parent, weight);
+            childArray[parent].offer(curr);
+        }
+
+        answer = 0;
+        dfs(1);
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
## 풀이과정

- 제일 처음에 착각한것
    - 트리 노드를 순서대로 줬구나! (그림만 보고 속단)
        - 아래에서부터 올라가면 되지 않을까?
        - dfs 대신 순서대로 순회해서 풀려고 함
    - 근데 순서대로 아니였음 → null pointer 오류 발생 → 결국 다시 DFS로 풂
- 기본 아이디어
    - 어떤 노드에서 그 하위의 리프 노드까지 두 경로를 합친 것이 리프노드에서 리프노드까지의 경로
        - 가중치 합이 최대인 경로+그 다음으로 가중치 합이 큰 경로를 구하자
    - 그래서 처음엔 priority queue 씀
        - 근데 오래 걸림 → 정렬하는데 너무 많은 시간 소비
    - 힌트 받고 max와 현재값만으로 구하는 방법으로 바꿈 → 한 번 순회로 모두 가능해짐 → 시간 단축