### PR TITLE
[240202] BOJ 3107 IPv6

### DIFF
--- a/seoyoung059/Week_02/BOJ_3107/BOJ_3107.java
+++ b/seoyoung059/Week_02/BOJ_3107/BOJ_3107.java
@@ -1,0 +1,62 @@
+package seoyoung059.Week_02;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+public class BOJ_3107 {
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        LinkedList<String> ll = new LinkedList<>();
+        String ipv6 = br.readLine();
+
+        int cnt=0;
+        char prev = ipv6.charAt(0);
+        // 생략된 ipv6 주소 받는 부분
+        for (int i = 1; i < ipv6.length(); i++) {
+            if(ipv6.charAt(i)==':'){
+                if(prev!=':') {
+                    sb.append(prev);
+                    ll.offer(sb.toString());
+                    cnt++;
+                } else {
+                    ll.offer(" ");
+                }
+                sb = new StringBuilder();
+            }
+            else {
+                if(prev!=':')
+                    sb.append(prev);
+                if (i==ipv6.length()-1)
+                    sb.append(ipv6.charAt(i));
+            }
+            prev = ipv6.charAt(i);
+        }
+        ll.offer(sb.toString());
+        cnt++;
+        sb.setLength(0);
+
+        // 주소 복원 부분
+        for (String s: ll) {
+            if(s.equals(" ")){
+                for (int i = 0; i < 8-cnt; i++) {
+                    sb.append("0000");
+                    sb.append(":");
+                }
+            }
+            else {
+                for (int i = 0; i < 4-s.length(); i++) {
+                    sb.append("0");
+                }
+                sb.append(s);
+                sb.append(":");
+            }
+        }
+        sb.setLength(39);
+
+        System.out.println(sb.toString());
+    }
+}

--- a/seoyoung059/Week_02/BOJ_3107/BOJ_3107.md
+++ b/seoyoung059/Week_02/BOJ_3107/BOJ_3107.md
@@ -1,0 +1,84 @@
+## 코드
+```java
+package javajava;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+public class BOJ_3107 {
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        LinkedList<String> ll = new LinkedList<>();
+        String ipv6 = br.readLine();
+        int cnt=0;
+        char prev = ipv6.charAt(0);
+        for (int i = 1; i < ipv6.length(); i++) {
+            if(ipv6.charAt(i)==':'){
+                if(prev!=':') {
+                    sb.append(prev);
+                    ll.offer(sb.toString());
+                    cnt++;
+                } else {
+                    ll.offer(" ");
+                }
+                sb = new StringBuilder();
+            }
+            else {
+                if(prev!=':')
+                    sb.append(prev);
+                if (i==ipv6.length()-1)
+                    sb.append(ipv6.charAt(i));
+            }
+            prev = ipv6.charAt(i);
+        }
+        ll.offer(sb.toString());
+        cnt++;
+        
+        
+        sb.setLength(0);
+        for (String s: ll) {
+            if(s.equals(" ")){
+                for (int i = 0; i < 8-cnt; i++) {
+                    sb.append("0000");
+                    sb.append(":");
+                }
+            }
+            else {
+                for (int i = 0; i < 4-s.length(); i++) {
+                    sb.append("0");
+                }
+                sb.append(s);
+                sb.append(":");
+            }
+        }
+        sb.setLength(39);
+        System.out.println(sb.toString());
+    }
+}
+```
+
+## 풀이과정
+
+- 주어진 문자열을 순회
+    - 문자열을 한칸씩 순회하고 이전 문자에 따라 다르게 동작하도록 한다.
+    - :마다 문자열을 자르고 그 수를 cnt로 더한다
+        
+        → 이후에 생략된 문자열 복원할 때 그 개수를 구하는데 사용
+        
+    - 현재 문자가 :일 때
+        - 이전 문자도 :이였으면 연속된 0000 생략 표시 → “ “ 문자열로 표시 후 나중에 다시 문자열 만들 때 모자른 문자열 수(8 - cnt)만큼 0000 출력
+        - 이전 문자가 :이 아니였으면 문자열 리스트에 추가 및 cnt 증가
+        - 어쨌든 문자열 끝난것이니 스트링빌더 초기화
+    - 현재 문자가 :이 아닐 때
+        - 문자열이 계속되고 있는 것이니 스트링빌더에 이전 문자 추가
+        - 마지막 문자면 현재 문자까지 추가
+
+### 알게된 것
+
+- StringBuilder setLength의 편리함
+    - 스트링빌더 새로 생성하는 것보다 setLength(0)하고 재사용하는 것이 아주 살짝… 더 빠르다고 한다.
+    - 주소 마지막에도 :가 찍혀나오는걸 어떻게 처리할까 고민했는데 이 또한 setLength로 잘라버렸다.


### PR DESCRIPTION
## 코드
```java
package seoyoung059.Week_02;

import java.io.BufferedReader;
import java.io.InputStreamReader;
import java.util.LinkedList;
import java.util.StringTokenizer;

public class BOJ_3107 {

    public static void main(String[] args) throws Exception{
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        StringBuilder sb = new StringBuilder();
        LinkedList<String> ll = new LinkedList<>();
        String ipv6 = br.readLine();

        int cnt=0;
        char prev = ipv6.charAt(0);
        // 생략된 ipv6 주소 받는 부분
        for (int i = 1; i < ipv6.length(); i++) {
            if(ipv6.charAt(i)==':'){
                if(prev!=':') {
                    sb.append(prev);
                    ll.offer(sb.toString());
                    cnt++;
                } else {
                    ll.offer(" ");
                }
                sb = new StringBuilder();
            }
            else {
                if(prev!=':')
                    sb.append(prev);
                if (i==ipv6.length()-1)
                    sb.append(ipv6.charAt(i));
            }
            prev = ipv6.charAt(i);
        }
        ll.offer(sb.toString());
        cnt++;
        sb.setLength(0);

        // 주소 복원 부분
        for (String s: ll) {
            if(s.equals(" ")){
                for (int i = 0; i < 8-cnt; i++) {
                    sb.append("0000");
                    sb.append(":");
                }
            }
            else {
                for (int i = 0; i < 4-s.length(); i++) {
                    sb.append("0");
                }
                sb.append(s);
                sb.append(":");
            }
        }
        sb.setLength(39);

        System.out.println(sb.toString());
    }
}
```

## 풀이과정

- 주어진 문자열을 순회
    - 문자열을 한칸씩 순회하고 이전 문자에 따라 다르게 동작하도록 한다.
    - :마다 문자열을 자르고 그 수를 cnt로 더한다
        → 이후에 생략된 문자열 복원할 때 그 개수를 구하는데 사용
    - 현재 문자가 :일 때
        - 이전 문자도 :이였으면 연속된 0000 생략 표시 
          → “ “ 문자열로 표시 후 나중에 다시 문자열 만들 때 모자른 문자열 수(8 - cnt)만큼 0000 출력
        - 이전 문자가 :이 아니였으면 문자열 리스트에 추가 및 cnt 증가
        - 어쨌든 두 경우(이전 문자가 :인 경우, :이 아닌 경우) 모두 문자열 끝난것이니 스트링빌더 초기화
    - 현재 문자가 :이 아닐 때
        - 문자열이 계속되고 있는 것이니 스트링빌더에 이전 문자 추가
        - 주소 전체의 마지막 문자면 현재 문자까지 추가

### 알게된 것
- StringBuilder setLength의 편리함
    - 스트링빌더 새로 생성하는 것보다 setLength(0)하고 재사용하는 것이 아주 살짝… 더 빠르다고 한다.
    - 주소 마지막에도 :가 찍혀나오는걸 어떻게 처리할까 고민했는데 이 또한 setLength로 잘라버렸다.