### PR TITLE
BOJ_3107_IPv6

### DIFF
--- a/violetadieu/Week_02/BOJ_3107_IPv6.py
+++ b/violetadieu/Week_02/BOJ_3107_IPv6.py
@@ -1,0 +1,16 @@
+ip = input()
+ips = ip.split(":")
+
+if len(ips[0])==0:
+    ips=ips[1:]
+elif len(ips[-1])==0:
+    ips=ips[:-1]
+
+result = ""
+for item in ips:
+    if len(item)==0:
+        result+="0000:"*(9-len(ips))
+    else:
+        result+=item.zfill(4)+":"
+
+print(result[:-1])


### PR DESCRIPTION
입력이 주어지는 경우

0. 주어진 문장을 : 단위로 split(핵심), 해당 배열을 이하 arr로 칭함

1. 1:2:3:4:5:6:7:8 ->자릿수만 채워주면 됨(ex.0001)
2. 1:2::8 -> arr의 원소 수를 신경쓰면서 '0000'을 채우기
3. ::1 -> 2번과 마찬가지이나, 초기 arr의 원소 수를 신경써야함(python의 경우 공백이 두개가 됨, 자바는 모르겠다)
4. 1:: -> 2번과 동일
5. :: ->'0000' 8번 출력

이후 출력

주의할 점
1. 콜론 가감하는거 빼먹지 않기
2. 시간&공간복잡도 절대 안터지니까 로직 너무 빡빡하게 짤 필요 없음
