### PR TITLE
[240221] BOJ 1043 거짓말

### DIFF
--- a/u1qns/Week_05/BOJ_1043_거짓말.java
+++ b/u1qns/Week_05/BOJ_1043_거짓말.java
@@ -1,0 +1,128 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static StringBuilder sb;
+	static StringTokenizer st;
+	static BufferedReader br;
+
+	static int parent[];
+	public static void main(String[] args) throws IOException {
+	
+		br = new BufferedReader(new InputStreamReader(System.in));
+		
+		// input
+		st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		parent = new int[N+2];
+		for(int i=1; i<=N; ++i)
+			parent[i] = -1;
+		
+		int arr[] = new int[N+1];
+		int answer = 0;
+		
+		st = new StringTokenizer(br.readLine());
+		int cnt = Integer.parseInt(st.nextToken());
+		int rep = 0;
+		
+		if(cnt == 0)
+		{
+			System.out.println(M);
+			return;
+		}
+		
+		if(cnt > 0)
+		{
+            arr[0] = Integer.parseInt(st.nextToken());
+			for(int i=1; i<cnt; ++i)
+			{
+				arr[i] = Integer.parseInt(st.nextToken());
+			    union(arr[0], arr[i]);
+            }
+		}
+
+		boolean flag = false;
+		int root = 0;
+		int party[][] = new int[M][N+2];
+        int size[] = new int[M];
+		for(int i=0; i<M; ++i)
+		{
+			st = new StringTokenizer(br.readLine()); 
+			size[i] = Integer.parseInt(st.nextToken());
+			
+			if(size[i]> 0)
+			{
+                flag = false;
+                party[i][0] = Integer.parseInt(st.nextToken());
+				for(int j = 1; j<size[i]; ++j)
+				{
+					party[i][j] = Integer.parseInt(st.nextToken());
+					union(party[i][0], party[i][j]);
+					if(find(party[i][j]) == find(arr[0])) flag = true;
+				}
+				
+				if(flag)
+				{
+					union(party[i][1], arr[0]);
+				}
+			}
+		}
+		
+		rep = find(arr[0]);
+		for(int i=0; i<M; ++i)
+		{
+			flag = false;
+			for(int j=0; j<size[i]; ++j)
+			{
+				root = find(party[i][j]);
+				if(root == rep) 
+				{
+					flag = true; 
+					break;
+				};
+			}
+			answer = (flag == false ? ++answer : answer);
+		}
+
+		
+		System.out.print(answer);
+		
+	} // main
+
+	private static int find(final int x)
+	{
+		if(parent[x] < 0) return x;
+		
+		return parent[x] = find(parent[x]);
+	}
+	
+	private static boolean union(final int a, final int b)
+	{
+		int p1 = find(a);
+		int p2 = find(b);
+		
+		if(p1 == p2) return false;
+		
+		if(Math.abs(p1) < Math.abs(p2))
+		{
+			parent[p2] += parent[p1];
+			parent[p1] = p2;
+			
+		}
+		else //if(Math.abs(p1) < Math.abs(p2))
+		{
+			parent[p1] += parent[p2];
+			parent[p2] = p1;
+		}
+		
+		return true;
+	}
+}


### PR DESCRIPTION
- 소요 시간 : 2시간 (…)
- 소스 코드 : [BOJ](https://www.acmicpc.net/source/73808206) / [git](https://github.com/BE-Archive/Algorithm-Study/commit/6b7e38e59f5d8af721cdb86393811da162fc76eb)
- 알고리즘 : union-find

---
###  접근법
1. 진실을 아는 친구를 같은 집합에 넣는다.
2. 파티에 참석한 애들끼리 집합을 만든다.
    - 이 과정에서 진실아는 애들이 섞이면 같은 부모를 갖게 된다.

이제 진실을 아는 친구 집합을 구했다.

저장한 파티를 다시 한번 싹 돌면서 참석자 전원이 진실 집합에 속하지 않으면 거짓말하게 둔다.

---

![image](https://github.com/BE-Archive/Algorithm-Study/assets/85053365/002e4c3e-a37b-44a1-9ca3-add748c1d7f9)

### 🔎 아쉬운 점

메모리 초과 원인을 찾고 싶었는데 이 로직의 차이였다.
진실을 아는 집합의 수가 cnt이면 바로 파티 개수 (M)을 출력하는 것이다.
인터넷을 검색했더니 다른 사람은 이런거 없이도 잘 통과되는 것 같아서 더 심란해졌다.

```
if(cnt == 0)
{
	System.out.println(M);
	return;
}
```
