### PR TITLE
[240301] BOJ 1931 회의실 배정

### DIFF
--- a/trankill1127/w06/BOJ_1931.java
+++ b/trankill1127/w06/BOJ_1931.java
@@ -1,0 +1,54 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_1931 {
+
+    public static class Meeting implements Comparable<Meeting>{
+        int s;
+        int e;
+        Meeting(int s,int e){
+            this.s=s;
+            this.e=e;
+        }
+        public String toString(){
+            return s+"~"+e;
+        }
+        @Override
+        public int compareTo(Meeting o) {
+            if (this.e==o.e){
+                return this.s-o.s;
+            }
+            return this.e-o.e;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n= Integer.parseInt(br.readLine());
+
+        StringTokenizer st;
+        Meeting[] timeList = new Meeting[n];
+        for (int i=0; i<n; i++){
+            st = new StringTokenizer(br.readLine(), " ");
+            int s=Integer.parseInt(st.nextToken());
+            int e=Integer.parseInt(st.nextToken());
+            timeList[i]=new Meeting(s,e);
+        }
+
+        Arrays.sort(timeList);
+
+        int cnt=0;
+        int befE=0;
+        for (int i=0; i<n; i++) {
+            if (befE <= timeList[i].s) {
+                befE=timeList[i].e;
+                cnt++;
+            }
+        }
+
+        System.out.println(cnt);
+    }
+}


### PR DESCRIPTION
## 이슈넘버
#172 

## 소스코드
```
import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;
import java.util.Arrays;
import java.util.StringTokenizer;

public class BOJ_1931 {

    public static class Meeting implements Comparable<Meeting>{
        int s;
        int e;
        Meeting(int s,int e){
            this.s=s;
            this.e=e;
        }
        public String toString(){
            return s+"~"+e;
        }
        @Override
        public int compareTo(Meeting o) {
            if (this.e==o.e){
                return this.s-o.s;
            }
            return this.e-o.e;
        }
    }

    public static void main(String[] args) throws IOException {
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        int n= Integer.parseInt(br.readLine());

        StringTokenizer st;
        Meeting[] timeList = new Meeting[n];
        for (int i=0; i<n; i++){
            st = new StringTokenizer(br.readLine(), " ");
            int s=Integer.parseInt(st.nextToken());
            int e=Integer.parseInt(st.nextToken());
            timeList[i]=new Meeting(s,e);
        }

        Arrays.sort(timeList);

        int cnt=0;
        int befE=0;
        for (int i=0; i<n; i++) {
            if (befE <= timeList[i].s) {
                befE=timeList[i].e;
                cnt++;
            }
        }

        System.out.println(cnt);
    }
}
```

## 소요시간
60분


## 알고리즘
그리디 알고리즘


## 풀이
**회의 시간이 겹치지 않는 최대 개수의 회의 조합을 찾아야 한다.**
회의의 최대개수는 10^5인데 이중 for문으로 완전탐색을 했다가는 10^10=100초로 시간초과가 발생한다.
즉, 머리를 써서 탐색 횟수를 줄여줘야 하는데 어떻게 할 수 있을까?

> 시작 시간을 오름차순으로 정렬하자. 
하나의 회의를 선택했다면 회의의 종료시간과 가장 가깝게 시작하는 회의를 다음 회의로 선택하자.

**하지만 이 로직은 항상 답을 보장해주지 못한다.**
이전 회의가 3시에 끝났고, 우리가 선택할 수 있는 회의는 ```A(3~8), B(4~5), C(5~7), D(7~8)```이 있다고 해보자.
```B(4~5), C(5~7), D(7~8)```를 선택하는 것이 우리가 원하는 답이다. 
하지만 위의 논리대로면 종료 시간 3시와 가장 가깝게 시작하는 회의 ```A(3~8)```만 선택하게 된다.

> 종료 시간을 오름차순으로 정렬하자. 
하나의 회의를 선택했다면 이 회의의 시작시간과 가장 가깝게 시작하는 회의를 다음 회의로 선택하자.

이 로직이 위의 상황에도 문제가 없는지 확인해보자.
전과 달리 회의가 ```B(4~5), C(5~7), A(3~8), D(7~8)```로 정렬될 것이며 ```B(4~5), C(5~7), D(7~8)```를 선택하게 될 것이다.
**따라서, 이 풀이는 항상 답을 보장해줄 수 있다!**
