### PR TITLE
[240301] BOJ 1931 회의실 배정

### DIFF
--- a/seoyoung059/Week_06/BOJ_1931/BOJ_1931.java
+++ b/seoyoung059/Week_06/BOJ_1931/BOJ_1931.java
@@ -1,0 +1,53 @@
+package Week_06.BOJ_1931;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_1931 {
+    static class P implements Comparable<P>{
+        int s;
+        int e;
+
+        P(int s, int e){
+            this.s = s;
+            this.e = e;
+        }
+
+        @Override
+        public String toString(){
+            return "["+this.s+" - "+e+"]";
+        }
+
+        @Override
+        public int compareTo(P o) {
+            if(this.e==o.e) return this.s - o.s;
+            return this.e - o.e;
+        }
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st ;
+        int n = Integer.parseInt(br.readLine());
+
+        PriorityQueue<P> pq = new PriorityQueue<>();
+        P curr = new P(-1,-1);
+        int answer = 0;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            pq.offer(new P(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())));
+        }
+
+        while(!pq.isEmpty()){
+            if(curr.e <= pq.peek().s){
+//                System.out.println(pq.peek());
+                curr = pq.poll();
+                answer ++;
+            }
+            else pq.poll();
+        }
+        System.out.println(answer);
+    }
+}

--- a/seoyoung059/Week_06/BOJ_1931/BOJ_1931.md
+++ b/seoyoung059/Week_06/BOJ_1931/BOJ_1931.md
@@ -1,0 +1,67 @@
+## 풀이과정
+
+- 그리디!
+    - ‘회의실을 사용할 수 있는 회의의 최대 개수’를 구하는 문제인데 분명히 규칙이 있을 것
+    - 주어진 것이 시작시간/종료시간이므로 이를 이용해야 한다.
+    - 그리디를 할 때는 ‘현재 시점’에서 가장 목표하는 바를 잘 이루는 방법이 뭔지 고민하는 것.
+        - 시작이 빠른 것은 회의가 엄청 길 수 있으므로 많은 회의 진행을 보장하지 않는다.
+        - 종료가 빠른 것은 그 이후에 존재하는 회의들을 최대한 많이 진행하는 방법 중 하나이다.
+            - 이 때, 시작과 종료가 같은 회의들이 존재하는 것을 생각하면, 종료 시간이 같으면 시작 시간이 빠른 것을 우선으로 확인해서, 어떤 회의 A가 끝나자마자 시작과 종료 시간이 같은 회의 B가 이루어져서 모두 진행될 수 있도록 할 수 있을 것이다.
+    - 따라서 입력받을 때 위와 같은 조건으로 정렬되도록 우선순위 큐에 삽입하고, 이를 꺼내면서 조건을 만족하는지 확인하는 방식으로 문제를 풀 수 있다.
+
+## 코드
+
+```java
+package Week_06.BOJ_1931;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_1931 {
+    static class P implements Comparable<P>{
+        int s;
+        int e;
+
+        P(int s, int e){
+            this.s = s;
+            this.e = e;
+        }
+
+        @Override
+        public String toString(){
+            return "["+this.s+" - "+e+"]";
+        }
+
+        @Override
+        public int compareTo(P o) {
+            if(this.e==o.e) return this.s - o.s;
+            return this.e - o.e;
+        }
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st ;
+        int n = Integer.parseInt(br.readLine());
+
+        PriorityQueue<P> pq = new PriorityQueue<>();
+        P curr = new P(-1,-1);
+        int answer = 0;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            pq.offer(new P(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())));
+        }
+
+        while(!pq.isEmpty()){
+            if(curr.e <= pq.peek().s){
+                curr = pq.poll();
+                answer ++;
+            }
+            else pq.poll();
+        }
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 이슈넘버
#172 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/74234981)


## 소요시간
20분

## 알고리즘
그리디 알고리즘


## 풀이
- 그리디!
    - ‘회의실을 사용할 수 있는 회의의 최대 개수’를 구하는 문제인데 분명히 규칙이 있을 것
    - 주어진 것이 시작시간/종료시간이므로 이를 이용해야 한다.
    - 그리디를 할 때는 ‘현재 시점’에서 가장 목표하는 바를 잘 이루는 방법이 뭔지 고민하는 것.
        - 시작이 빠른 것은 회의가 엄청 길 수 있으므로 많은 회의 진행을 보장하지 않는다.
        - 종료가 빠른 것은 그 이후에 존재하는 회의들을 최대한 많이 진행하는 방법 중 하나이다.
            - 이 때, 시작과 종료가 같은 회의들이 존재하는 것을 생각하면, 종료 시간이 같으면 시작 시간이 빠른 것을 우선으로 확인해서, 어떤 회의 A가 끝나자마자 시작과 종료 시간이 같은 회의 B가 이루어져서 모두 진행될 수 있도록 할 수 있을 것이다.
    - 따라서 입력받을 때 위와 같은 조건으로 정렬되도록 우선순위 큐에 삽입하고, 이를 꺼내면서 조건을 만족하는지 확인하는 방식으로 문제를 풀 수 있다.
