### PR TITLE
[240311] BOJ 1522 문자열 교환

### DIFF
--- a/u1qns/Week_08/BOJ_1522_문자열교환.java
+++ b/u1qns/Week_08/BOJ_1522_문자열교환.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+
+    final static int INF = Integer.MAX_VALUE;
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int answer = len-;
+        int a = 0, b = 0;
+        int len, idx = 0;
+
+        String input = br.readLine();
+        len = input.length();
+
+        for(int i=0; i<len; ++i)
+            if(input.charAt(i) == 'a') ++a;
+
+        for(int i=0; i<len; ++i)
+        {
+            b = 0;
+            if(input.charAt(i) == 'a') continue;
+            for(int j=0; j<a; ++j)
+            {
+                idx = (i+j+1) % len;
+                if(input.charAt(idx) == 'b')
+                    ++b;
+            }
+            answer = Math.min(answer, b);
+        }
+        
+        System.out.print(answer==INF ? 0 : answer);
+    }
+}


### PR DESCRIPTION
## 이슈넘버
#210 

## 소스코드
```java
import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;

public class Main {

    final static int INF = Integer.MAX_VALUE;
    public static void main(String[] args) throws IOException {

        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

        int answer = INF;
        int a = 0, b = 0;
        int len, idx = 0;

        String input = br.readLine();
        len = input.length();

        for(int i=0; i<len; ++i)
            if(input.charAt(i) == 'a') ++a;

        for(int i=0; i<len; ++i)
        {
            b = 0;
            if(input.charAt(i) == 'a') continue;
            for(int j=0; j<a; ++j)
            {
                idx = (i+j+1) % len;
                if(input.charAt(idx) == 'b')
                    ++b;
            }
            //System.out.println("i : " + i + "\t" + b);
            answer = Math.min(answer, b);
        }
        
        if(answer == INF)
            answer = 0;
        
        System.out.print(answer);
    }
}
```

## 소요시간
60분

## 알고리즘
슬라이딩 윈도우

## 풀이
🤔  **아이디어 1**

- 알고리즘 : 투포인터
- 양끝에 start, end라는 포인터를 둔다.
- start는  b를 찾을 때까지 이동하며, end는 a를 찾을 때까지 이동한다.
- start가 b를 만나면 교환했다고 생각하고 ++answer 해준다.
- start와 end가 만나면 종료한다.

**반례**
   
  ```jsx
  baab
  ba
  baaab
  abbba
  //answer : 0
  ```
    
양 끝이 같을 경우 조건이나 총 a, b의 개수로 비교를 해주어도 해결 안 되는 경우가 생겼다.

🤔 **아이디어 2**

- 위의 반례를 해결하다가 a, b의 개수를 이용할 순 없을까 ? 라는 생각이 들었다.
- 입력받은 문자열에서 a, b의 개수를 저장한다.
- ~~b의 개수가 곧 최대 교환 횟수라 answer에 저장한다.~~ **이건 틀린 생각이다. 아래에 설명있음**
- 그 이후로.. 고민을 계속 하다가 [연속되어야 하는 문자열의 a 개수]를 이미 들고 있잖아? 라는 생각이 들었다.
- b가 있는 위치에서 a개의 범위 내에 b가 하나도 없으면 교환을 안 해도 되겠다.

### 💡 최종 : a 범위만큼 잘라서 b의 개수를 세어 최소값을 출력하자

--- 

_어디서 부터 탐색을 시작해야 할까? answer의 초기값은 뭘로 지정해야할까_

그냥 고민했던 김에 적어봤습니다. 

`b가 있는 위치에서 탐색 시작` && `answer의 초기값 : b의 개수`

- aaaa
    - b가 하나도 없어서 answer 초기값이 정답이 된다.
    - 초기값으로 answer = 0 지정하면 min값을 구하기 힘들어진다.
    - 초기값answer = b 그럴싸해서 b의 개수로 지정하려고 했지만?
- bbb
    - 초기값을 b의 개수로 지정해두었다면 정답은 0 이지만 output이 3이다.

그래서 answer 초기값을 INF로 두고 정답 제출 전에 answer의 값이 변한 적 없다면 0으로 출력하도록 조정해주어야 한다. 

모든 위치에서 슬라이딩 윈도우를 하면 이런 짓을 안 해도 되긴한데 나름 시간을 아낄 수 있지 않을까 생각해서 넣은 로직이었는데 돌려보니 시간은 똑같았다 !