### PR TITLE
[240311] BOJ 1522 문자열 교환

### DIFF
--- a/trankill1127/w08/BOJ_1522.java
+++ b/trankill1127/w08/BOJ_1522.java
@@ -1,0 +1,24 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+public class BOJ_1522 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        char[] s = br.readLine().toCharArray();
+        int aCnt=0;
+        for (int i=0; i<s.length; i++) {
+            if (s[i]=='a') aCnt++;
+        }
+
+        int minCnt=Integer.MAX_VALUE;
+        for (int i=0; i<s.length; i++) {
+            int cnt=0;
+            for (int j=0; j<aCnt; j++) {
+                if (s[(i+j)%s.length]=='b') cnt++;
+            }
+            if (minCnt>cnt) minCnt=cnt;
+        }
+
+        System.out.println(minCnt);
+    }
+}


### PR DESCRIPTION
## 이슈넘버
#210 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/74759879)

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
120분

## 알고리즘
슬라이딩 윈도우

## 풀이
### 첫번째 시도 
원형 문자열이라는 조건 때문에 주어진 문자열의 양 끝이 모두 a인 경우, b인 경우, 서로 다른 경우까지 3가지 경우를 따져봐야 한다고 생각했다. 그래서 경우의 수를 강제로 줄이기 위해 덱을 이용해서 왼쪽은 b, 오른쪽은 a로 끝나는 형태로 문자열 순서를 바꿔줬다. 그리고 왼쪽부터 시작하는 left, 오른쪽부터 시작하는 right을 이용해서 a와 b의 위치를 바꿔주고, 그 교환 횟수를 계산했다.

하지만 틀렸습니다의 늪을 벗어날 수 없었다. 열심히 고민해서 찾아낸 반례는 아래와 같다. 3이 나와야 하는데, 내 코드로는 5로 계산된다.
```
bbbaaabbbbbbbaa
``` 

문제의 원인을 파악해서 개선할 수도 있었겠지만 이미 충분히 고민해봤다고 판단하고 다른 사람들의 도움을 받았다.

### 두번째 시도 : 슬라이딩 윈도우
다들 이 방법으로 푼 것 같아서 이 방법에 대한 풀이는 생략한다.