### PR TITLE
[240320] BOJ 16234 인구이동

### DIFF
--- a/seoyoung059/Week_09/BOJ_16234/BOJ_16234.java
+++ b/seoyoung059/Week_09/BOJ_16234/BOJ_16234.java
@@ -1,0 +1,98 @@
+package Week_09.BOJ_16234;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_16234 {
+
+    public static void main(String[] args) throws Exception{
+
+        // Input
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int l = Integer.parseInt(st.nextToken());
+        int r = Integer.parseInt(st.nextToken());
+
+
+        int[][] arr = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+
+        int answer = -1;        // 0초부터 시작
+        int[] dy = {1,-1,0,0};
+        int[] dx = {0,0,1, -1};
+        boolean going = true;   // 인구 이동 없을 시 시뮬레이션 종료
+
+        // q: BFS 큐, opened: 인구 이동 영역 체크
+        ArrayDeque<Integer> q = new ArrayDeque<>();
+        ArrayDeque<Integer> opened = new ArrayDeque<>();
+
+
+        boolean[][] visited = new boolean[n][n];
+        int curr; int ny, nx, tmp, cnt, sum;
+
+        boolean now = false; // visited 배열 초기화하는 대신 매 시뮬레이션마다 now인 것이 unvisited인것으로 체크
+
+        // 시뮬레이션
+        while (going) {
+            going = false;
+            cnt = 0; answer++;
+
+            // visited에 따라 bfs 수행
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if(visited[i][j] == now){
+                        q.offerLast(i*n+j);         // bfs 시작점
+                        opened.offer(q.peekLast());     // 인구 이동 큐에도 추가
+                        visited[i][j] = !now;           // visited로 표시
+                        sum=arr[i][j];                  // 인구 count
+
+                        // BFS
+                        while(!q.isEmpty()) {
+                            curr = q.pollFirst();
+                            for (int k = 0; k < 4; k++) {
+                                ny = curr/n+dy[k];
+                                nx = curr%n+dx[k];
+
+                                if(ny<0 || nx<0 || ny>=n||nx>=n) continue;
+
+                                // 인구 차이 확인 후 bfs 큐 추가, 인구 이동 추가 및 visited 표시, 인구 count
+                                tmp = Math.abs(arr[ny][nx]-arr[curr/n][curr%n]);
+                                if(visited[ny][nx]==now && l<=tmp && tmp<=r){
+                                    q.offerLast(ny*n+nx);
+                                    opened.offer(q.peekLast());
+                                    visited[ny][nx] = !now;
+                                    sum+=arr[ny][nx];
+                                }
+                            }
+                        }
+
+                        // 인구 이동
+                        sum /= opened.size();
+                        if(opened.size()>1) {           // 두 개 도시 이상이여야 이동이 의미있다
+                            while (!opened.isEmpty()) {
+                                going = true;           // 인구 이동 발생 -> 시뮬레이션 반복 조건 체크
+                                curr = opened.pollFirst();
+                                arr[curr/n][curr%n] = sum;  //인구 값 업데이트
+                            }
+                        }
+                        else opened.clear();    // 초기화
+                    }
+                }
+            }
+            now=!now;   // visited 변경
+        }
+        System.out.println(answer);
+    }
+}

--- a/seoyoung059/Week_09/BOJ_16234/BOJ_16234.md
+++ b/seoyoung059/Week_09/BOJ_16234/BOJ_16234.md
@@ -1,0 +1,110 @@
+## 풀이과정
+
+- 처음에 union-find로 풀어야하나 했는데 그냥 BFS 시뮬레이션 문제이다.
+    - 매 단계마다
+        - 각 칸별로 bfs를 수행하고 누적합 sum을 구한다.
+        - 한 bfs 수행에서 묶인 칸들을 다른 arraydeque opened에다가 저장해둔다
+        - 해당 bfs가 종료되면 sum을 opened.size()로 나눈 값으로 인구를 분배해주었다.
+- 새로운 시도
+    - 매 시뮬레이션 단계마다 visited 배열을 확인하면서 전체가 다 바뀌기 때문에, visited를 초기화하는 대신 해당 단계의 unvisited를 now 변수로 지정해서 그것을 기준으로 방문여부를 확인할 수 있었다.
+
+## 코드
+
+```java
+package Week_09.BOJ_16234;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_16234 {
+
+    public static void main(String[] args) throws Exception{
+
+        // Input
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int l = Integer.parseInt(st.nextToken());
+        int r = Integer.parseInt(st.nextToken());
+
+        int[][] arr = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int answer = -1;        // 0초부터 시작
+        int[] dy = {1,-1,0,0};
+        int[] dx = {0,0,1, -1};
+        boolean going = true;   // 인구 이동 없을 시 시뮬레이션 종료
+
+        // q: BFS 큐, opened: 인구 이동 영역 체크
+        ArrayDeque<Integer> q = new ArrayDeque<>();
+        ArrayDeque<Integer> opened = new ArrayDeque<>();
+
+        boolean[][] visited = new boolean[n][n];
+        int curr; int ny, nx, tmp, cnt, sum;
+
+        boolean now = false; // visited 배열 초기화하는 대신 매 시뮬레이션마다 now인 것이 unvisited인것으로 체크
+
+        // 시뮬레이션
+        while (going) {
+            going = false;
+            cnt = 0; answer++;
+
+            // visited에 따라 bfs 수행
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if(visited[i][j] == now){
+                        q.offerLast(i*n+j);         // bfs 시작점
+                        opened.offer(q.peekLast());     // 인구 이동 큐에도 추가
+                        visited[i][j] = !now;           // visited로 표시
+                        sum=arr[i][j];                  // 인구 count
+                        
+                        // BFS
+                        while(!q.isEmpty()) {
+                            curr = q.pollFirst();
+                            for (int k = 0; k < 4; k++) {
+                                ny = curr/n+dy[k];
+                                nx = curr%n+dx[k];
+
+                                if(ny<0 || nx<0 || ny>=n||nx>=n) continue;
+                                
+                                // 인구 차이 확인 후 bfs 큐 추가, 인구 이동 추가 및 visited 표시, 인구 count
+                                tmp = Math.abs(arr[ny][nx]-arr[curr/n][curr%n]);
+                                if(visited[ny][nx]==now && l<=tmp && tmp<=r){
+                                    q.offerLast(ny*n+nx);
+                                    opened.offer(q.peekLast());
+                                    visited[ny][nx] = !now;
+                                    sum+=arr[ny][nx];
+                                }
+                            }
+                        }
+
+                        // 인구 이동
+                        sum /= opened.size();
+                        if(opened.size()>1) {           // 두 개 도시 이상이여야 이동이 의미있다
+                            while (!opened.isEmpty()) {
+                                going = true;           // 인구 이동 발생 -> 시뮬레이션 반복 조건 체크
+                                curr = opened.pollFirst();
+                                arr[curr/n][curr%n] = sum;  //인구 값 업데이트
+                            }
+                        }
+                        else opened.clear();    // 초기화
+                    }
+                }
+            }
+            now=!now;   // visited 변경
+        }
+        System.out.println(answer);
+    }
+}
+
+```


### PR DESCRIPTION
## 이슈넘버
#247 

## 소스코드

[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/75364531)

## 소요시간
40분

## 알고리즘
BFS, 시뮬레이션


## 풀이

- 처음에 union-find로 풀어야하나 했는데 그냥 BFS 시뮬레이션 문제이다.
    - 매 단계마다
        - 각 칸별로 bfs를 수행하고 누적합 sum을 구한다.
        - 한 bfs 수행에서 묶인 칸들을 다른 arraydeque opened에다가 저장해둔다
        - 해당 bfs가 종료되면 sum을 opened.size()로 나눈 값으로 인구를 분배해주었다.
- 새로운 시도
    - 매 시뮬레이션 단계마다 visited 배열을 확인하면서 전체가 다 바뀌기 때문에, visited를 초기화하는 대신 해당 단계의 unvisited를 now 변수로 지정해서 그것을 기준으로 방문여부를 확인할 수 있었다.
