### PR TITLE
[240331] BOJ 16234 인구 이동

### DIFF
--- a/trankill1127/w09/BOJ_16234.java
+++ b/trankill1127/w09/BOJ_16234.java
@@ -1,0 +1,99 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ_16234 {
+
+    public static class Pair{
+        int x, y;
+
+        public Pair(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public String toString() {
+            return "Pair{" +
+                    "x=" + x +
+                    ", y=" + y +
+                    '}';
+        }
+    }
+
+    public static int n, l, r;
+    public static int[][] map;
+    public static int[][] visited;
+    public static int[][] direction = {
+            {-1,0},{1,0},{0,-1},{0,1}
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        n= Integer.parseInt(st.nextToken());
+        l= Integer.parseInt(st.nextToken());
+        r= Integer.parseInt(st.nextToken());
+        map = new int[n][n];
+        for (int i=0; i<n; i++){
+            st = new StringTokenizer(br.readLine(), " ");
+            for (int j=0; j<n; j++){
+                map[i][j]=Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int daysCnt=0;
+        while (true) { //하루 단위
+            visited=new int[n][n];
+        	boolean flag = false;
+            
+            for (int i=0; i<n; i++){
+                for (int j=0; j<n; j++){
+                    if (visited[i][j]==1) continue;
+                    if (bfs(i,j)) {
+                    	flag=true;
+                    }
+                }
+            }
+            if (flag) daysCnt++;
+            else break;
+        }
+
+        System.out.println(daysCnt);
+    }
+
+    public static boolean bfs(int x, int y){
+        Queue<Pair> q = new LinkedList<>();
+        q.add(new Pair(x,y));
+        visited[x][y]=1;
+        int countryPpl=map[x][y];
+
+        List<Pair> listForCalc = new LinkedList<>();
+        listForCalc.add(new Pair(x,y));
+
+        while (!q.isEmpty()){
+            Pair now=q.poll();
+
+            for (int i=0; i<4; i++){
+                int nextX = now.x+direction[i][0];
+                int nextY = now.y+direction[i][1];
+                if (nextX<0 || nextX>=n || nextY<0 || nextY>=n || visited[nextX][nextY]==1) continue;
+
+                int diff = Math.abs(map[now.x][now.y]-map[nextX][nextY]);
+                if (l<=diff && diff<=r){
+                    visited[nextX][nextY]=1;
+                    countryPpl+=map[nextX][nextY];
+                    q.add(new Pair(nextX, nextY));
+                    listForCalc.add(new Pair(nextX,nextY));
+                }
+            }
+        }
+
+        for (Pair p : listForCalc){
+            map[p.x][p.y]=countryPpl/listForCalc.size();
+        }
+
+        if (listForCalc.size()>1) return true;
+        else return false;
+    }
+}
+


### PR DESCRIPTION
## 이슈넘버
#247 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/75386649)

## 소요시간
180분

## 알고리즘
BFS

## 풀이
1단계. 연합을 파악한다.
* 인접한 나라의 인구수 차이가 L 이상, R 이하인 경우에 두 나라는 연합을 이룬다.
* 여러개의 연합이 발생할 수 있다!

2단계. 연합 간의 인구 이동이 발생한다.

3단계. 인구 이동이 더 이상 발생하지 않을 때까지 이를 반복한다.

#### 왜 시간이 오래 걸렸는가?
시간을 조금 더 줄여보려고 main에서 bfs 실행 전에 한번 더 그 좌표가 인접한 나라가 있는지 확인하는 코드를 추가했었다. 그런데 4방향을 모두 확인해야 하는데 도중에 연합을 이루지 않는 방향이 있다면 break를 해버려서 일부 예제 케이스가 이상하게 출력되는 것이었다... 이거 파악하는 데 2시간은 썼다.