### PR TITLE
[240327] BOJ 2866 문자열 잘라내기

### DIFF
--- a/ys4512558/Week_10/BOJ_2866_문자열잘라내기/BOJ_2866_문자열잘라내기.java
+++ b/ys4512558/Week_10/BOJ_2866_문자열잘라내기/BOJ_2866_문자열잘라내기.java
@@ -1,0 +1,36 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        char[][] chars = new char[M][N];
+        StringBuilder[] stringBuilders = new StringBuilder[M];
+        for (int i = 0; i < M; i++) {
+            stringBuilders[i] = new StringBuilder();
+        }
+        for (int i = 0; i < N; i++) {
+            String input = br.readLine();
+            for (int j = 0; j < M; j++) {
+                stringBuilders[j].append(input.charAt(j));
+            }
+        }
+
+        int cnt = 0;
+        Loop:for (int i = 1; i < N; i++) {
+            Set<String> set = new TreeSet<>();
+            for (int j = 0; j < M; j++) {
+                stringBuilders[j] = stringBuilders[j].delete(0, 1);
+                if(!set.add(stringBuilders[j].toString())) break Loop;
+            }
+            cnt++;
+        }
+        System.out.println(cnt);
+    }
+}

--- a/ys4512558/Week_10/BOJ_2866_문자열잘라내기/BOJ_2866_문자열잘라내기.md
+++ b/ys4512558/Week_10/BOJ_2866_문자열잘라내기/BOJ_2866_문자열잘라내기.md
@@ -1,0 +1,68 @@
+# 소스코드
+
+```Java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        char[][] chars = new char[M][N];
+        StringBuilder[] stringBuilders = new StringBuilder[M];
+        for (int i = 0; i < M; i++) {
+            stringBuilders[i] = new StringBuilder();
+        }
+        for (int i = 0; i < N; i++) {
+            String input = br.readLine();
+            for (int j = 0; j < M; j++) {
+                stringBuilders[j].append(input.charAt(j));
+            }
+        }
+
+        int cnt = 0;
+        Loop:for (int i = 1; i < N; i++) {
+            Set<String> set = new TreeSet<>();
+            for (int j = 0; j < M; j++) {
+                stringBuilders[j] = stringBuilders[j].delete(0, 1);
+                if(!set.add(stringBuilders[j].toString())) break Loop;
+            }
+            cnt++;
+        }
+        System.out.println(cnt);
+    }
+}
+```
+
+# 소요시간
+
+30분
+
+# 알고리즘
+
+# 풀이
+
+구현
+
+# BOJ 2866 문자열 잘라내기
+
+# 기본 로직
+
+1. 문자열을 입력받을 때 행과 열을 바꿔주며 저장한다.
+2. StringBuilder를 사용하여 모든 행의 왼쪽 열의 문자를 삭제하고 이를 set에 넣어준다.
+3. 중복되는 경우가 있다면 더 이상 추가하지 못하는 경우이므로 현재까지의 행의 개수를 출력한다.
+
+---
+
+## 질문 (페어야 도와줘!)
+
+1. TreeSet을 사용하는 경우와 HashSet을 사용하는 경우의 시간차이가 약 1.7배 정도 나는 것을 확인했다.
+2. HashSet이 검색에서 O(1)이라 더 빠를 것으로 예상되었지만, 결과가 반대이다. (왜 그런지 알려주세요..ㅠㅠ)
+3. 검색해본 결과 더욱 모르겠음. (트리셋의 경우 정렬을 하며 추가하기 때문에 더 느리다고 하는데 왜 더 빠를까요?!)
+
+---


### PR DESCRIPTION
## 이슈넘버
#263 
# 소스코드

```Java
import java.io.*;
import java.util.*;

public class Main {
    public static void main(String[] args) throws IOException {
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
        StringTokenizer st = new StringTokenizer(br.readLine());

        int N = Integer.parseInt(st.nextToken());
        int M = Integer.parseInt(st.nextToken());

        char[][] chars = new char[M][N];
        StringBuilder[] stringBuilders = new StringBuilder[M];
        for (int i = 0; i < M; i++) {
            stringBuilders[i] = new StringBuilder();
        }
        for (int i = 0; i < N; i++) {
            String input = br.readLine();
            for (int j = 0; j < M; j++) {
                stringBuilders[j].append(input.charAt(j));
            }
        }

        int cnt = 0;
        Loop:for (int i = 1; i < N; i++) {
            Set<String> set = new TreeSet<>();
            for (int j = 0; j < M; j++) {
                stringBuilders[j] = stringBuilders[j].delete(0, 1);
                if(!set.add(stringBuilders[j].toString())) break Loop;
            }
            cnt++;
        }
        System.out.println(cnt);
    }
}
```

# 소요시간

30분

# 알고리즘

# 풀이

구현

# BOJ 2866 문자열 잘라내기

# 기본 로직

1. 문자열을 입력받을 때 행과 열을 바꿔주며 저장한다.
2. StringBuilder를 사용하여 모든 행의 왼쪽 열의 문자를 삭제하고 이를 set에 넣어준다.
3. 중복되는 경우가 있다면 더 이상 추가하지 못하는 경우이므로 현재까지의 행의 개수를 출력한다.

---

## 질문 (페어야 도와줘!)

1. TreeSet을 사용하는 경우와 HashSet을 사용하는 경우의 시간차이가 약 1.7배 정도 나는 것을 확인했다.
2. HashSet이 검색에서 O(1)이라 더 빠를 것으로 예상되었지만, 결과가 반대이다. (왜 그런지 알려주세요..ㅠㅠ)
3. 검색해본 결과 더욱 모르겠음. (트리셋의 경우 정렬을 하며 추가하기 때문에 더 느리다고 하는데 왜 더 빠를까요?!)

---