### PR TITLE
[240327] BOJ 2866 문자열 잘라내기

### DIFF
--- a/seoyoung059/Week_10/BOJ_2866.java
+++ b/seoyoung059/Week_10/BOJ_2866.java
@@ -1,0 +1,50 @@
+package Ing;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ_2866 {
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int r = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        HashSet<String> set;
+
+        char[][] arr = new char[r][c];
+        String str;
+        for (int i = 0; i < r; i++) {
+            str = br.readLine();
+            for (int j = 0; j < c; j++) {
+                arr[i][j] = str.charAt(j);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        String[] tmp = new String[c];
+        for (int i = 0; i < c; i++) {
+            for (int j = 0; j < r; j++) {
+                sb.append(arr[j][i]);
+            }
+            tmp[i] = sb.toString();
+            sb = new StringBuilder();
+        }
+        int answer = r-1;
+        loop: for (int i = 1; i < r; i++) {
+            set = new HashSet<>();
+            for (int j = 0; j < c; j++) {
+                if(set.contains(tmp[j].substring(i))){
+                    answer = i-1;
+                    break loop;
+                }
+                else{
+                    set.add(tmp[j].substring(i));
+                }
+            }
+        }
+
+        System.out.println(answer);
+    }
+}

--- a/seoyoung059/Week_10/BOJ_2866.md
+++ b/seoyoung059/Week_10/BOJ_2866.md
@@ -1,0 +1,58 @@
+## 풀이과정
+
+- 가로로 주어진 문자열을 세로로 재구성하여, 앞에서부터 잘라가며 같은 문자열이 있으면 탐색을 종료한다.
+- 같은 문자열 → 매번 비교할 수 없으니 해시를 쓰는 것이 좋다.
+- 앞에서부터 문자열을 자름 → 자바의 substring을 사용해서 해시셋의 값으로 넣고, 있으면 탐색 종료, 없으면 해시에 추가하며 이후에 확인할 수 있도록 한다.
+
+## 코드
+
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int r = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        HashSet<String> set;
+
+        char[][] arr = new char[r][c];
+        String str;
+        for (int i = 0; i < r; i++) {
+            str = br.readLine();
+            for (int j = 0; j < c; j++) {
+                arr[i][j] = str.charAt(j);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        String[] tmp = new String[c];
+        for (int i = 0; i < c; i++) {
+            for (int j = 0; j < r; j++) {
+                sb.append(arr[j][i]);
+            }
+            tmp[i] = sb.toString();
+            sb = new StringBuilder();
+        }
+        int answer = r-1;  
+        loop: for (int i = 1; i < r; i++) {
+            set = new HashSet<>();
+            for (int j = 0; j < c; j++) {
+                if(set.contains(tmp[j].substring(i))){
+                    answer = i-1;
+                    break loop;
+                }
+                else{
+                    set.add(tmp[j].substring(i));
+                }
+            }
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 이슈넘버
#263 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/75854606)


## 소요시간
40분


## 알고리즘
구현, 해시


## 풀이
- 가로로 주어진 문자열을 세로로 재구성하여, 앞에서부터 잘라가며 같은 문자열이 있으면 탐색을 종료한다.
- 같은 문자열 → 매번 비교할 수 없으니 해시를 쓰는 것이 좋다.
- 앞에서부터 문자열을 자름 → 자바의 substring을 사용해서 해시셋의 값으로 넣고, 있으면 탐색 종료, 없으면 해시에 추가하며 이후에 확인할 수 있도록 한다.

