### PR TITLE
[230401] BOJ 15501 부당한 퍼즐

### DIFF
--- a/trankill1127/w11/BOJ_15501.java
+++ b/trankill1127/w11/BOJ_15501.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+public class BOJ_15501 {
+
+	public static void main(String[] args) throws IOException{
+		// TODO Auto-generated method stub
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		
+		int[] arr1 = new int[n];
+		int[] arr2 = new int[n];
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		for (int i=0; i<n; i++) {
+			arr1[i]=Integer.parseInt(st.nextToken());
+
+		}
+		st = new StringTokenizer(br.readLine(), " ");
+		for (int i=0; i<n; i++) arr2[i]=Integer.parseInt(st.nextToken());
+		
+		boolean isPossible=false;
+		
+		//뒤집기 전
+		ArrayDeque<Integer> d = new ArrayDeque<>(n);
+		for (int i=0; i<n; i++) d.add(arr1[i]);
+		while (d.getFirst()!=arr2[0]) d.add(d.pollFirst());
+		for (int i=0; i<n; i++) arr1[i]=d.pollFirst();
+		for (int i=0; i<n; i++) {
+			if (arr1[i]!=arr2[i]) break;
+			else {
+				if (i==n-1) isPossible=true;
+			}
+		}
+		
+		//뒤집기 후
+		if (!isPossible) {
+			for (int i=n-1; i>=0; i--) d.add(arr1[i]);
+			while (d.getFirst()!=arr2[0]) d.add(d.pollFirst());
+			for (int i=0; i<n; i++) arr1[i]=d.pollFirst();
+			for (int i=0; i<n; i++) {
+				if (arr1[i]!=arr2[i]) break;
+				else {
+					if (i==n-1) isPossible=true;
+				}
+			}
+		}
+		
+		if (isPossible) System.out.println("good puzzle");
+		else System.out.println("bad puzzle");
+	}
+}


### PR DESCRIPTION
## 이슈넘버
#274 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/76097645)

## 소요시간
20분

## 알고리즘
?

## 풀이
1~n의 숫자로 이뤄진 2개의 수열이 있을 때
- 뒤집거나
- 왼쪽/오른쪽으로 밀기

 2가지 작업만으로 첫번째 수열을 두번째 수열로 만들 수 있는지 확인해야 한다.

순서를 섞는 작업은 없기 때문에 가능한 경우의 수는 정방향 수열 n개, 역방향 수열 n개를 합해서 2n개다.

하지만 이 수열을 모두 타겟 수열과 같은지 비교한다면 2n*n이 되어버린다.
이 부분에서 효율성을 높이기 위해서
1. 두 수열이 다르다고 idx 위치에서 밝혀지면 idx+1 ~ n-1은 검사하지 않는다.
2. 정방향 검사에서 타겟 수열로 만드는 게 가능함이 확인된다면, 굳이 역방향으로 수열을 확인하지 않는다.

이렇게 2가지를 추가적으로 구현해줬다.