### PR TITLE
[230401] BOJ 15501 부당한 퍼즐

### DIFF
--- a/seoyoung059/Week_11/BOJ_15501/BOJ_15501.java
+++ b/seoyoung059/Week_11/BOJ_15501/BOJ_15501.java
@@ -1,0 +1,49 @@
+package Week_11.BOJ_15501;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_15501 {
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int[] arr1 = new int[n];
+        int[] arr2 = new int[n];
+        for (int i = 0; i < n; i++) {
+            arr1[i] = Integer.parseInt(st.nextToken());
+        }
+        int start = arr1[0];
+        int beginIdx=-1;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr2[i] = Integer.parseInt(st.nextToken());
+            if(arr2[i]==start) beginIdx = i;
+        }
+
+        boolean answer = true;
+        if(n==1){
+            answer = (arr1[0]==arr2[0])?true:false;
+        }
+        else if(arr2[(beginIdx+1)%n]==arr1[1]){
+            for (int i = 0; i < n; i++) {
+                if(arr1[i]!= arr2[(beginIdx+i)%n]) {
+                    answer = false;
+                    break;
+                }
+            }
+        }
+        else {
+            for (int i = 0; i < n; i++) {
+                if(arr1[i]!=arr2[(beginIdx+n-i)%n]) {
+                    answer = false;
+                    break;
+                }
+            }
+        }
+        System.out.println(answer?"good puzzle":"bad puzzle");
+    }
+}

--- a/seoyoung059/Week_11/BOJ_15501/BOJ_15501.md
+++ b/seoyoung059/Week_11/BOJ_15501/BOJ_15501.md
@@ -1,0 +1,56 @@
+## 풀이과정
+- 1~n까지의 숫자가 한 번씩만 나타나는 수열을 뒤집거나 밀어서 다른 주어지는 다른 수열로 바꿀 수 있는지를 확인하는 문제이다.
+- 이 때, '뒤집기'와 '밀기'는 숫자의 근본적인 순서를 바꾸지 않는다!
+  - '뒤집기'는 앞에서 뒤로, 뒤에서 앞으로의 순서를 바꾼다
+  - '밀기'는 수열의 시작 순서를 바꿀 뿐 순서를 바꾸진 않는다.
+
+## 코드
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int[] arr1 = new int[n];
+        int[] arr2 = new int[n];
+        for (int i = 0; i < n; i++) {
+            arr1[i] = Integer.parseInt(st.nextToken());
+        }
+        int start = arr1[0];
+        int beginIdx=-1;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr2[i] = Integer.parseInt(st.nextToken());
+            if(arr2[i]==start) beginIdx = i;
+        }
+
+        boolean answer = true;
+        if(n==1){
+            answer = (arr1[0]==arr2[0])?true:false;
+        }
+        else if(arr2[(beginIdx+1)%n]==arr1[1]){
+            for (int i = 0; i < n; i++) {
+                if(arr1[i]!= arr2[(beginIdx+i)%n]) {
+                    answer = false;
+                    break;
+                }
+            }
+        }
+        else {
+            for (int i = 0; i < n; i++) {
+                if(arr1[i]!=arr2[(beginIdx+n-i)%n]) {
+                    answer = false;
+                    break;
+                }
+            }
+        }
+        System.out.println(answer?"good puzzle":"bad puzzle");
+    }
+}
+```


### PR DESCRIPTION
## 이슈넘버
#274 

## 소스코드
```java
import java.io.BufferedReader;
import java.io.InputStreamReader;
import java.util.StringTokenizer;

public class Main {

    public static void main(String[] args) throws Exception{
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        int n = Integer.parseInt(br.readLine());

        StringTokenizer st = new StringTokenizer(br.readLine());
        int[] arr1 = new int[n];
        int[] arr2 = new int[n];
        for (int i = 0; i < n; i++) {
            arr1[i] = Integer.parseInt(st.nextToken());
        }
        int start = arr1[0];
        int beginIdx=-1;
        st = new StringTokenizer(br.readLine());
        for (int i = 0; i < n; i++) {
            arr2[i] = Integer.parseInt(st.nextToken());
            if(arr2[i]==start) beginIdx = i;
        }

        boolean answer = true;
        if(n==1){
            answer = (arr1[0]==arr2[0])?true:false;
        }
        else if(arr2[(beginIdx+1)%n]==arr1[1]){
            for (int i = 0; i < n; i++) {
                if(arr1[i]!= arr2[(beginIdx+i)%n]) {
                    answer = false;
                    break;
                }
            }
        }
        else {
            for (int i = 0; i < n; i++) {
                if(arr1[i]!=arr2[(beginIdx+n-i)%n]) {
                    answer = false;
                    break;
                }
            }
        }
        System.out.println(answer?"good puzzle":"bad puzzle");
    }
}
```

## 소요시간
15분

## 알고리즘
구현


## 풀이
- 1~n까지의 숫자가 한 번씩만 나타나는 수열을 뒤집거나 밀어서 다른 주어지는 다른 수열로 바꿀 수 있는지를 확인하는 문제이다.
- 이 때, '뒤집기'와 '밀기'는 숫자의 근본적인 순서를 바꾸지 않는다!
  - '뒤집기'는 앞에서 뒤로, 뒤에서 앞으로의 순서를 바꾼다
  - '밀기'는 수열의 시작 순서를 바꿀 뿐 순서를 바꾸진 않는다.
