### PR TITLE
[240406] BOJ 15927 회문은 회문 아니야!!

### DIFF
--- a/trankill1127/w11/BOJ_15927.java
+++ b/trankill1127/w11/BOJ_15927.java
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_15927 {
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        char[] s = br.readLine().toCharArray();
+
+        //팰린드롬인지 확인한다.
+        int left=0, right=s.length-1;
+        while (left<right && s[left]==s[right]){
+            left++; right--;
+        }
+        //팰린드롬이 아니라면
+        if (left<right){
+            System.out.println(s.length);
+        }
+        else { //팰린드롬이면
+            int sameCnt=0;
+            for (int i=0; i<s.length; i++){
+                if (s[0]==s[i]) sameCnt++;
+                else break;
+            }
+            if (sameCnt==s.length) { //모든 문자가 동일하면
+                System.out.println(-1);
+            }
+            else { //동일하지 않으면
+                System.out.println(s.length-1);
+            }
+        }
+    }
+}
+
+/*
+11:50-
+
+펠린드롬이 아닌 가장 긴 부분문자열의 길이를 구해보자
+길이 1~50만
+있으면 길이를, 없으면 -1 출력
+
+아니 근데 문제가 이상한데???
+
+펠린드롬인 경우
+- 모두 같은 경우
+- 그렇지 않은 경우
+펠린드롬이 아닌 경우 (여기서 작은 펠린드롬이 존재할 수 있는 거 아닌가?)
+ */


### PR DESCRIPTION
## 이슈넘버
#294 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/76436488)

## 소요시간
1시간 30분

## 알고리즘
에드 혹

## 풀이 
### 전체 문자열이 펠린드롬이 아닌 경우 
`전체 문자열의 길이`
#### ✍🏽 왜 헤맸는가?
**팰린드롬의 길이가 L일 때, 펠린드롬이 아닌 가장 긴 부분 문자열의 길이는 L-1이다**에 꽂혀서 문자열에서 가장 긴 펠린드롬을 찾느라 헤맸다... 부분 문자열 중에 펠린드롬이 있다고 해도, 결국 펠린드롬이 아닌 가장 긴 부분 문자열은 전체 문자열이기 때문에 이럴 필요가 없었다.

### 전체 문자열이 펠린드롬인 경우
- 문자열의 모든 문자가 동일한 경우 `-1`
- 그렇지 않은 경우 `전체 문자열의 길이-1`
