### PR TITLE
[240412] BOJ 14226 이모티콘

### DIFF
--- a/trankill1127/w12/BOJ_14226.java
+++ b/trankill1127/w12/BOJ_14226.java
@@ -1,0 +1,61 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class BOJ_14226 {
+
+    public static class Status {
+        int viewLen;
+        int clipboardLen;
+        int time;
+
+        public Status(int viewLen, int clipboardLen, int time) {
+            this.viewLen = viewLen;
+            this.clipboardLen = clipboardLen;
+            this.time = time;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        s = Integer.parseInt(br.readLine());
+        bfs();
+        System.out.println(result);
+    }
+
+    public static int s;
+    public static int result;
+    public static int[][] visited = new int[1001][1001];
+
+    public static void bfs() {
+        Queue<Status> q = new LinkedList<>();
+        q.add(new Status(1, 0, 0));
+        visited[1][0] = 1;
+
+        while (!q.isEmpty()) {
+            Status now = q.poll();
+            if (now.viewLen == s) {
+                result = now.time;
+                break;
+            }
+
+            if (now.clipboardLen > 0 &&
+                    (now.viewLen + now.clipboardLen) <= 1000 &&
+                    visited[now.viewLen + now.clipboardLen][now.clipboardLen] == 0) {
+                q.add(new Status(now.viewLen + now.clipboardLen, now.clipboardLen, now.time + 1));
+                visited[now.viewLen + now.clipboardLen][now.clipboardLen] = 1;
+            }
+            if (visited[now.viewLen][now.viewLen] == 0) {
+                q.add(new Status(now.viewLen, now.viewLen, now.time + 1));
+                visited[now.viewLen][now.viewLen] = 1;
+            }
+            if (now.viewLen - 1 >= 0 && visited[now.viewLen - 1][now.clipboardLen] == 0) {
+                q.add(new Status(now.viewLen - 1, now.clipboardLen, now.time + 1));
+                visited[now.viewLen - 1][now.clipboardLen] = 1;
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
## 이슈넘버
#316 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/76862360)

## 소요시간
3시간 30분

## 알고리즘
BFS

## 풀이
### 나의 풀이: DP
2시간 정도 사용한 시점에 안 풀리길래 풀이를 봤는데 BFS길래 당황했다.

### 다른 사람의 풀이 : BFS
일단 이 문제에서 완전탐색을 해야하는 이유를 사례를 들어 설명해보겠다. 
현재 화면에 이모티콘이 6개, 클립보드에 2개가 있으면, 클립보드를 활용해서 6, 8, 10, 12... 와 같이 이모티콘을 생성할 수 있다.
처음에 이 부분을 간과해서 dp로 풀 수 있겠다고 생각했었다.

암튼 완탐을 돌아야 한다. 어떻게 돌 수 있을까?
별거 없다. 걍 연산 하나씩 돌아간 경우를 큐에 넣어주면 된다.
대신, 예외처리를 좀 잘해주야 한다...
안 그러면 시간초과도 걸리고, 난리도 아님.

첫번째 : 클립보드 내용 추가
두번째 : 클립보드에 복사
마지막: 화면에 있는 거 하나 삭제

첫번째 경우에는 이미 visited 체크된 조건은 아닌지, 클립보드에 이모티콘 개수가 1개 이상인지, 화면에 추가시 길이가 우리가 목표한 것보다 길어지는 것은 아닌지 확인해야 한다.
두번째 경우는 클립보드 임티 화면에 복붙 케이스로 이게 첫번째 경우의 3번째 조건문을 만족해야 한다.
마지막 경우는 화면에서 임티를 하나 빼도 0개 이상인지, 방문한 적이 없어야 한다.
