### PR TITLE
[240419] BOJ 4195 친구 네트워크

### DIFF
--- a/trankill1127/w13/BOJ_4195.java
+++ b/trankill1127/w13/BOJ_4195.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+public class BOJ_4195 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int t=Integer.parseInt(br.readLine());
+        for (int tc=1; tc<=t; tc++){
+
+            int f=Integer.parseInt(br.readLine());
+            parent=new int[f*2+1];
+            Arrays.fill(parent, -1);
+
+            names.clear();
+            int nameIdx=1;
+
+            StringTokenizer st;
+            for (int i=0; i<f; i++){
+                st = new StringTokenizer(br.readLine().trim());
+                String left = st.nextToken();
+                String right = st.nextToken();
+
+                if (!names.containsKey(left)){
+                    names.put(left, nameIdx);
+                    nameIdx++;
+                }
+                if (!names.containsKey(right)){
+                    names.put(right, nameIdx);
+                    nameIdx++;
+                }
+                int leftIdx=names.get(left);
+                int rightIdx=names.get(right);
+
+                int std = union(leftIdx, rightIdx);
+                sb.append(-parent[std]).append("\n");
+            }
+        }
+        System.out.println(sb.toString());
+    }
+
+    public static HashMap<String, Integer> names = new HashMap<>();
+    public static int[] parent;
+
+    public static int find(int x){
+        if (parent[x]<0) return x;
+        return parent[x] = find(parent[x]);
+    }
+
+    public static int union(int idx1, int idx2){
+        int p1=find(idx1);
+        int p2=find(idx2);
+
+        if (p1==p2) return p1;
+        else if (p1<p2){
+            parent[p1]+=parent[p2];
+            parent[p2]=p1;
+            return p1;
+        }
+        else {
+            parent[p2]+=parent[p1];
+            parent[p1]=p2;
+            return p2;
+        }
+    }
+}


### PR DESCRIPTION
## 이슈넘버
#345 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/77220581)

## 소요시간
2시간 30분

## 알고리즘
유니온 파인드

## 풀이
시간초과(5%)의 벽을 해결하지 못하고 여기저기 풀이를 구걸하러 다닌 결과 수빈언니♥️의 도움으로 풀 수 있었다.

#### 1) 이름을 저장하는 방법

'무한정 추가할 수 있는 자료구조면... ArrayList지!'라고 단정지어 버린게 문제였다...
처음에 사용했던 방법은 `ArrayList<String> names`에 새로운 이름이 들어올 때마다 add하는 것이었다. 하지만 이러면 이름의 위치를 찾을 때 `ArrayList<String>`을 전부 다 돌아야 하며 최악의 경우 O(f^2)의 시간복잡도를 보이게 된다. f이 최대 10^5이니 이미 여기서 시간초과가 날 이유가 충분했다..😔

`ArrayList` 대신 `HashMap<String, Integer>`를 사용하여 이름을 찾는 과정의 시간 복잡도를 O(1)까지 줄일 수 있었다. 

#### 2) 네트워크를 구성하는 인원을 세는 방법

처음에 사용했던 방법은 parent 배열을 갱신하고 매번 같은 부모를 갖는 인원을 세는 것이었다. 하지만 이렇게 하면 최악의 경우 O(f^2)의 시간복잡도를 보이게 된다. 

흔히 쓰이는 union-find 구현방법을 떠올려 보자.
parent 배열에서 자식 노드는 자신의 부모가 누구인지 저장하지만 부모 노드가 하는 역할은... 딱히 없다.
`parent[x]==x`일 때 부모라고 파악할 수 있게 해주는 게 전부다.
그런데 잘 머리를 쓰면 **부모 노드에 그 그룹에 속한 인원이 몇명인지도 저장하게 할 수 있다!**

우선 parent 배열을 전부 -1로 초기화한다. 이 값의 의미는 `-1 x 그룹에 소속된 인원`이다.
`find()`에서는 `parent[x]<0`일 때 부모로 판단하도록 수정한다.
`union()`에서는 두 사람의 부모 노드 인덱스가 각각 p1, p2고 p1<p2라고 하자.
부모 노드가 되는 `parent[p1]`에 자식 노드가 되는 `parent[p2]`를 더해줘서 그룹에 소속된 인원수를 합쳐주고, 
자식 노드에는 `parent[p2]=p1`으로 수정하여 합쳐진 노드가 자신의 부모가 누구인지 저장하도록 했다. 
이렇게 하면 따로 검사 과정 없이 바로 친구 네트워크에 현재 몇명이 있는지 확인할 수 있으므로 시간 복잡도를 O(1)까지 줄일 수 있다.