### PR TITLE
[240424] BOJ 16197 두 동전

### DIFF
--- a/u1qns/Week_14/BOJ_16197_두동전.java
+++ b/u1qns/Week_14/BOJ_16197_두동전.java
@@ -1,0 +1,138 @@
+import java.io.*;
+import java.util.*;
+
+public class Main { // BFS 방식 
+
+    final static int WALL = 1;
+    final static int EMPTY = 0;
+    final static int[][] direction = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+
+    static int N, M;
+    static int[][] arr;
+
+    static class Coin
+    {
+        public Coin(int x, int y, int type)
+        {
+            this.x = x;
+            this.y = y;
+            this.type = type;
+        }
+
+        int x, y, type;
+    }
+    
+    static class cPair
+    {
+        cPair(Coin c1, Coin c2)
+        {
+            this.c1 = c1;
+            this.c2 = c2;
+        }
+
+        Coin c1;
+        Coin c2;
+    }
+    static boolean isValid(final int x, final int y)
+    {
+        if(x<0 || y<0 || x>=N || y>=M)
+            return false;
+        return true;
+    }
+
+    static int getAnswer(final List<int[]> coin)
+    {
+        int time = 0;
+
+        Queue<cPair> q = new ArrayDeque<>();
+
+        cPair front;
+        Coin c1, c2;
+
+        int x, x2, y, y2, type, type2;
+
+        q.add(new cPair(
+                new Coin (coin.get(0)[0], coin.get(0)[1], 0),
+                new Coin (coin.get(1)[0], coin.get(1)[1], 1)
+        ));
+
+        while(!q.isEmpty())
+        {
+            if(time++ == 10)
+                return -1;
+
+            int qSize = q.size();
+            while(qSize-- > 0)
+            {
+                front = q.poll();
+                c1 = front.c1; type = c1.type;
+                c2 = front.c2; type2 = c2.type;
+
+                for(int[] d : direction)
+                {
+                    x = c1.x + d[0]; y = c1.y + d[1];
+                    x2 = c2.x + d[0]; y2 = c2.y + d[1];
+
+                    boolean r1 = isValid(x, y);
+                    boolean r2 = isValid(x2, y2);
+
+                    if(r1 != r2) return time;
+                    if(!r1 && !r2) continue;
+
+                    if(r1 && r2)
+                    {
+                        if(arr[x][y] == WALL)
+                        {
+                            x = c1.x; y = c1.y;
+                        }
+                        if(arr[x2][y2] == WALL)
+                        {
+                            x2 = c2.x; y2 = c2.y;
+                        }
+                        q.offer(new cPair(new Coin(x, y, type), new Coin(x2, y2, type2)));
+                    }
+                } // d
+            }
+        }
+
+        return -1;
+    }
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        String input;
+        List<int[]> coin = new ArrayList<>();
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        arr = new int[N][M];
+
+        for(int i=0; i<N; i++)
+        {
+            input = br.readLine();
+            for(int j=0; j<M; j++)
+            {
+                switch(input.charAt(j))
+                {
+                    case 'o':
+                        arr[i][j] = EMPTY;
+                        coin.add(new int[]{i, j});
+                        break;
+                    case '.':
+                        arr[i][j] = EMPTY;
+                        break;
+                    case '#':
+                        arr[i][j] = WALL;
+                        break;
+                }
+            }
+        }
+
+        System.out.print(getAnswer(coin));
+    } // main
+}


### PR DESCRIPTION
## 이슈넘버
#364 

## 소스코드
[클릭하면 백준 코드로 이동됩니다. (DFS 버전 : 212ms/Java8)](https://www.acmicpc.net/source/77430998)
[클릭하면 백준 코드로 이동됩니다. (BFS 버전 : 276ms/Java8)](https://www.acmicpc.net/source/77429276)

## 소요시간
60분

## 알고리즘
BFS, DFS

## 풀이

DFS로 풀어도 좋고, BFS로 풀어도 좋다. 
둘 다 해봤는데 DFS가 속도가 더 빠르다. 

길이 막혔을 때 어쩔 수 없이 같은 지점에 머물러야 하기 때문에 일부러 재방문 처리를 하지 않았다. 
BFS 특성상 사방탐색을 하면서 방문했던 곳을 만나긴하는데 이 문제에서는 최대 이동횟수가 10번이라 무시했다.
반면에 DFS는 이동횟수(depth)가 10이고 가지 않은 곳만 가게 되니 더 유리한 것으로 생각된다. 



### 궁금한 점
만약에 문제에서 맵의 크기를 20x20가 아니라 엄청 컸거나, 이동횟수 제한을 크게 줬더라면 ?? 🤔🤔🤔... 