### PR TITLE
[240429] BOJ 1516 게임 개발

### DIFF
--- a/trankill1127/w15/BOJ_1516.java
+++ b/trankill1127/w15/BOJ_1516.java
@@ -1,0 +1,62 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ_1516 {
+
+    public static int n;
+    public static int[] time;
+    public static int[] in;
+    public static ArrayList<ArrayList<Integer>> graph;
+    public static int[] minTime;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        n = Integer.parseInt(br.readLine());
+        graph = new ArrayList<>();
+        for (int i=0; i<n+1; i++) graph.add(new ArrayList<>());
+        time = new int[n+1];
+        in = new int[n+1];
+        minTime = new int[n+1];
+
+        for (int i=1; i<n+1; i++){
+            st = new StringTokenizer(br.readLine().trim());
+            time[i]=Integer.parseInt(st.nextToken());
+            in[i]=st.countTokens()-1;
+            while (true){
+                int input = Integer.parseInt(st.nextToken());
+                if (input==-1) break;
+                graph.get(input).add(i);
+            }
+        }
+
+        bfs();
+
+        StringBuilder sb = new StringBuilder();
+        for (int i=1; i<n+1; i++) sb.append(minTime[i]).append("\n");
+        System.out.print(sb.toString());
+    }
+
+    public static void bfs(){
+        Queue<Integer> q =new LinkedList<>();
+        for (int i=1; i<=n; i++){
+            if (in[i]==0) {
+                q.add(i);
+                minTime[i]=time[i];
+            }
+        }
+
+        while (!q.isEmpty()){
+            int now = q.poll();
+            for (int next: graph.get(now)) {
+                minTime[next]=Math.max(minTime[next], minTime[now]+time[next]);
+                in[next]--;
+                if (in[next]==0){
+                    q.add(next);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 이슈넘버
#378 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/77630690)

## 소요시간
2시간

## 알고리즘
위상정렬, DP, BFS

## 풀이
i번째로 건물을 지으려 하는데 A 건물과 B 건물을 모두 지을 수 있다고 해보자.
A 건물을 선택하는 경우, B 건물을 선택하는 경우를 모두 고려해야 하는데 그러려면 **A 건물을 짓기로 하면서 갱신된 `진입 차수`와 `누적 시간`을 B 건물을 새우기 전에 어떤 건물도 짓기 전인 초기 상태로 돌려줘야 한다.**
나는 이것 때문에 재귀로 구현했는데 그랬더니 시간초과로 4%에서 컷 당해버렸다.... :(

도저히 개선을 어떻게 해야 될지 모르겠어서 풀이를 봤는데 DP 문제라고 해서 당황스러웠다.

### ```minTime[next]=Math.max(minTime[next], minTime[now]+time[next]);```
위 코드를 말로 풀어보자면,
```
next 건물을 완성한 시각
= Math.max(next 건물을 완성한 시각, 
now 건물을 완성한 시각 + next 건물을 짓는데 걸리는 시간)
```
다.
나는 대체 왜 `Math.max`를 써야 하는건지 모르겠어서 고민을 좀 했는데 아래 링크의 글을 읽고 이해할 수 있었다!

https://jjong2.tistory.com/m/55