### PR TITLE
[240507] BOJ 15644 구슬 탈출 3

### DIFF
--- a/seoyoung059/Week_16/BOJ_15644/BOJ_15644.java
+++ b/seoyoung059/Week_16/BOJ_15644/BOJ_15644.java
@@ -1,0 +1,227 @@
+package Week_16.BOJ_15644;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+public class BOJ_15644 {
+
+
+    static char[][] arr;
+    static ArrayDeque<int[]> q;
+    static boolean[][][][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        arr = new char[n][m];
+        int[] curr = new int[5];
+
+        String str;
+        for (int i = 0; i < n; i++) {
+            str = br.readLine();
+            for (int j = 0; j < m; j++) {
+                arr[i][j] = str.charAt(j);
+                switch (arr[i][j]) {
+                    case 'R':
+                        curr[0] = i;
+                        curr[1] = j;
+                        arr[i][j] = '.';
+                        break;
+                    case 'B':
+                        curr[2] = i;
+                        curr[3] = j;
+                        arr[i][j] = '.';
+                        break;
+                }
+            }
+        }
+
+        q = new ArrayDeque<>();
+        q.offer(curr);
+        visited = new boolean[n][m][n][m];
+        visited[curr[0]][curr[1]][curr[2]][curr[3]] = true;
+        int qSize, ry, rx, by, bx, i, trace = 0;
+        boolean found = false;
+        loop:
+        for (i = 0; i < 10; i++) {
+            qSize = q.size();
+            while (qSize-- > 0) {
+                curr = q.pollFirst();
+                ry = curr[0];
+                rx = curr[1];
+                by = curr[2];
+                bx = curr[3];
+                if (curr[0] > curr[2]) {
+                    // 위로 확인할땐 blue 먼저
+                    while (arr[by - 1][bx] == '.') by--;
+                    while (arr[ry - 1][rx] == '.' && !(by == ry - 1 && bx == rx)) ry--;
+
+                    if (arr[by - 1][bx] != 'O') {
+                        if (arr[ry - 1][rx] == 'O') {
+                            found = true;
+                            trace = curr[4]<<2;
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2)});
+                        }
+                    }
+
+                    // 아래로 확인할 땐 red 먼저
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[ry + 1][rx] == '.') ry++;
+                    while (arr[by + 1][bx] == '.' && !(ry == by + 1 && rx == bx)) by++;
+
+                    if(arr[ry+1][rx]=='O' && !(ry==by+1 && rx==bx)){
+                        found = true;
+                        trace = (curr[4]<<2|1);
+                        break loop;
+                    }
+                    if(arr[by+1][bx]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|1)});
+                    }
+
+                } else {
+                    // 위로 확인할땐 red 먼저
+                    while (arr[ry - 1][rx] == '.') ry--;
+                    while (arr[by - 1][bx] == '.' && !(ry == by - 1 && bx == rx)) by--;
+                    if(arr[ry-1][rx]=='O' && !(ry==by-1 && rx==bx)){
+                        found = true;
+                        trace = (curr[4]<<2);
+                        break loop;
+                    }
+                    if(arr[by-1][bx]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2)});
+                    }
+
+
+                    // 아래로 확인할 땐 blue 먼저
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[by + 1][bx] == '.') by++;
+                    while (arr[ry + 1][rx] == '.' && !(by == ry + 1 && rx == bx)) ry++;
+                    if (arr[by + 1][bx] != 'O') {
+                        if (arr[ry + 1][rx] == 'O') {
+                            found = true;
+                            trace = (curr[4]<<2|1);
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|1)});
+                        }
+                    }
+
+
+                }
+
+                if (curr[1] > curr[3]) {
+                    // 왼쪽으로 확인할 땐 blue 먼저
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[by][bx - 1] == '.') bx--;
+                    while (arr[ry][rx - 1] == '.' && !(bx == rx - 1 && by == ry)) rx--;
+                    if (arr[by][bx-1] != 'O') {
+                        if (arr[ry][rx-1] == 'O') {
+                            found = true;
+                            trace = (curr[4]<<2|2);
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|2)});
+                        }
+                    }
+
+
+                    // 오른쪽으로 확인할 땐 red 먼저
+                    rx = curr[1];
+                    bx = curr[3];
+                    while (arr[ry][rx + 1] == '.') rx++;
+                    while (arr[by][bx + 1] == '.' && !(rx == bx + 1 && ry == by)) bx++;
+                    if(arr[ry][rx+1]=='O' && !(rx==bx+1 && ry==by)){
+                        found = true;
+                        trace = (curr[4]<<2|3);
+                        break loop;
+                    }
+                    if(arr[by][bx+1]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|3)});
+                    }
+
+
+                } else {
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[ry][rx - 1] == '.') rx--;
+                    while (arr[by][bx - 1] == '.' && !(rx == bx - 1 && by == ry)) bx--;
+                    if(arr[ry][rx-1]=='O' && !(rx==bx-1 && ry==by)){
+                        found = true;
+                        trace = (curr[4]<<2|2);
+                        break loop;
+                    }
+                    if(arr[by][bx-1]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|2)});
+                    }
+
+
+                    rx = curr[1];
+                    bx = curr[3];
+                    while (arr[by][bx + 1] == '.') bx++;
+                    while (arr[ry][rx + 1] == '.' && !(bx == rx + 1 && ry == by)) rx++;
+                    if (arr[by][bx+1] != 'O') {
+                        if (arr[ry][rx+1] == 'O') {
+                            found = true;
+                            trace = (curr[4]<<2|3);
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|3)});
+                        }
+                    }
+
+
+                }
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        if(!found){
+            sb.append(-1);
+        } else {
+            for (int j = 0; j < i+1; j++) {
+                switch (trace&3) {
+                    case 0:
+                        sb.insert(0,'U');
+                        break;
+                    case 1:
+                        sb.insert(0,'D');
+                        break;
+                    case 2:
+                        sb.insert(0,'L');
+                        break;
+                    case 3:
+                        sb.insert(0,'R');
+                        break;
+                }
+                trace>>=2;
+            }
+            sb.insert(0, "\n").insert(0, i+1);
+        }
+        System.out.println(sb);
+    }
+
+
+}

--- a/seoyoung059/Week_16/BOJ_15644/BOJ_15644.md
+++ b/seoyoung059/Week_16/BOJ_15644/BOJ_15644.md
@@ -1,0 +1,246 @@
+## 풀이 과정
+- 비효율의 극치인 코드 길이... 하지만 풀이 방식이 함수로 분리하기에도 애매해서 그냥 했다.
+- 두 구슬의 x좌표, y좌표를 각각 비교하여 어떤 구슬을 먼저 움직일지 결정한다!
+  - 예를 들어, 판을 오른쪽으로 기울일 때에는 더 오른쪽에 있는(x좌표가 더 큰) 구슬을 먼저 움직인다.
+- 그리고 움직이는 순서에 따라 상태 판단도 달라진다.
+  - 빨간 구슬이 먼저 움직였다면, 빨간 구슬이 구멍에 들어가면서 파란 구슬이 구멍에 안 들어가는것을 확인해야한다.
+  - 반대로, 파란 구슬이 먼저 움직였다면, 파란 구슬이 구멍에 들어가지 않은 상태이면서 빨간 구슬이 들어갔는지를 확인해야 한다.
+- 중간에 디버깅이 필요했던 부분
+  - 구슬의 위치에 대해 분기할때 초기 위치로만 확인해서 문제가 틀렸었다.
+- 판을 어떻게 움직일지에 대해서는, 10번만 움직이면 되고, 4방향으로만 기울일 수 있으므로 비트를 사용했다.
+  - 위로 기울일때를 00, 아래로 기울일때를 01, 왼쪽으로 기울일때를 10, 오른쪽으로 기울일때를 11로 두개의 비트로 표현 가능하다.
+  - 최대 2x10=20비트만을 사용해서 트래킹을 할 수 있다.
+  - 따라서 상태를 저장할 때 2비트씩 왼쪽으로 shift 연산하고, 방향 숫자를 or 연산하여 저장했다.
+  - 빨간 구슬만 탈출시키기를 성공했을 때는 오른쪽으로 2비트씩 넘기면서 어떻게 움직였었는지를 역순으로 확인할 수 있다.
+
+## 코드
+```java
+package Week_16.BOJ_15644;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+public class BOJ_15644 {
+
+
+    static char[][] arr;
+    static ArrayDeque<int[]> q;
+    static boolean[][][][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        arr = new char[n][m];
+        int[] curr = new int[5];
+
+        String str;
+        for (int i = 0; i < n; i++) {
+            str = br.readLine();
+            for (int j = 0; j < m; j++) {
+                arr[i][j] = str.charAt(j);
+                switch (arr[i][j]) {
+                    case 'R':
+                        curr[0] = i;
+                        curr[1] = j;
+                        arr[i][j] = '.';
+                        break;
+                    case 'B':
+                        curr[2] = i;
+                        curr[3] = j;
+                        arr[i][j] = '.';
+                        break;
+                }
+            }
+        }
+
+        q = new ArrayDeque<>();
+        q.offer(curr);
+        visited = new boolean[n][m][n][m];
+        visited[curr[0]][curr[1]][curr[2]][curr[3]] = true;
+        int qSize, ry, rx, by, bx, i, trace = 0;
+        boolean found = false;
+        loop:
+        for (i = 0; i < 10; i++) {
+            qSize = q.size();
+            while (qSize-- > 0) {
+                curr = q.pollFirst();
+                ry = curr[0];
+                rx = curr[1];
+                by = curr[2];
+                bx = curr[3];
+                if (curr[0] > curr[2]) {
+                    // 위로 확인할땐 blue 먼저
+                    while (arr[by - 1][bx] == '.') by--;
+                    while (arr[ry - 1][rx] == '.' && !(by == ry - 1 && bx == rx)) ry--;
+
+                    if (arr[by - 1][bx] != 'O') {
+                        if (arr[ry - 1][rx] == 'O') {
+                            found = true;
+                            trace = curr[4]<<2;
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2)});
+                        }
+                    }
+
+                    // 아래로 확인할 땐 red 먼저
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[ry + 1][rx] == '.') ry++;
+                    while (arr[by + 1][bx] == '.' && !(ry == by + 1 && rx == bx)) by++;
+
+                    if(arr[ry+1][rx]=='O' && !(ry==by+1 && rx==bx)){
+                        found = true;
+                        trace = (curr[4]<<2|1);
+                        break loop;
+                    }
+                    if(arr[by+1][bx]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|1)});
+                    }
+
+                } else {
+                    // 위로 확인할땐 red 먼저
+                    while (arr[ry - 1][rx] == '.') ry--;
+                    while (arr[by - 1][bx] == '.' && !(ry == by - 1 && bx == rx)) by--;
+                    if(arr[ry-1][rx]=='O' && !(ry==by-1 && rx==bx)){
+                        found = true;
+                        trace = (curr[4]<<2);
+                        break loop;
+                    }
+                    if(arr[by-1][bx]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2)});
+                    }
+
+
+                    // 아래로 확인할 땐 blue 먼저
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[by + 1][bx] == '.') by++;
+                    while (arr[ry + 1][rx] == '.' && !(by == ry + 1 && rx == bx)) ry++;
+                    if (arr[by + 1][bx] != 'O') {
+                        if (arr[ry + 1][rx] == 'O') {
+                            found = true;
+                            trace = (curr[4]<<2|1);
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|1)});
+                        }
+                    }
+
+
+                }
+
+                if (curr[1] > curr[3]) {
+                    // 왼쪽으로 확인할 땐 blue 먼저
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[by][bx - 1] == '.') bx--;
+                    while (arr[ry][rx - 1] == '.' && !(bx == rx - 1 && by == ry)) rx--;
+                    if (arr[by][bx-1] != 'O') {
+                        if (arr[ry][rx-1] == 'O') {
+                            found = true;
+                            trace = (curr[4]<<2|2);
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|2)});
+                        }
+                    }
+
+
+                    // 오른쪽으로 확인할 땐 red 먼저
+                    rx = curr[1];
+                    bx = curr[3];
+                    while (arr[ry][rx + 1] == '.') rx++;
+                    while (arr[by][bx + 1] == '.' && !(rx == bx + 1 && ry == by)) bx++;
+                    if(arr[ry][rx+1]=='O' && !(rx==bx+1 && ry==by)){
+                        found = true;
+                        trace = (curr[4]<<2|3);
+                        break loop;
+                    }
+                    if(arr[by][bx+1]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|3)});
+                    }
+
+
+                } else {
+                    ry = curr[0];
+                    by = curr[2];
+                    while (arr[ry][rx - 1] == '.') rx--;
+                    while (arr[by][bx - 1] == '.' && !(rx == bx - 1 && by == ry)) bx--;
+                    if(arr[ry][rx-1]=='O' && !(rx==bx-1 && ry==by)){
+                        found = true;
+                        trace = (curr[4]<<2|2);
+                        break loop;
+                    }
+                    if(arr[by][bx-1]!='O' && !visited[ry][rx][by][bx]) {
+                        visited[ry][rx][by][bx] = true;
+                        q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|2)});
+                    }
+
+
+                    rx = curr[1];
+                    bx = curr[3];
+                    while (arr[by][bx + 1] == '.') bx++;
+                    while (arr[ry][rx + 1] == '.' && !(bx == rx + 1 && ry == by)) rx++;
+                    if (arr[by][bx+1] != 'O') {
+                        if (arr[ry][rx+1] == 'O') {
+                            found = true;
+                            trace = (curr[4]<<2|3);
+                            break loop;
+                        }
+                        if (!visited[ry][rx][by][bx]) {
+                            visited[ry][rx][by][bx] = true;
+                            q.offerLast(new int[]{ry, rx, by, bx, (curr[4] << 2|3)});
+                        }
+                    }
+
+
+                }
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        if(!found){
+            sb.append(-1);
+        } else {
+            for (int j = 0; j < i+1; j++) {
+                switch (trace&3) {
+                    case 0:
+                        sb.insert(0,'U');
+                        break;
+                    case 1:
+                        sb.insert(0,'D');
+                        break;
+                    case 2:
+                        sb.insert(0,'L');
+                        break;
+                    case 3:
+                        sb.insert(0,'R');
+                        break;
+                }
+                trace>>=2;
+            }
+            sb.insert(0, "\n").insert(0, i+1);
+        }
+        System.out.println(sb);
+    }
+
+
+}
+
+```


### PR DESCRIPTION
## 이슈넘버
#395

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/78016660)

## 소요시간
80분

## 알고리즘
BFS


## 풀이
- 비효율의 극치인 코드 길이... 하지만 풀이 방식이 함수로 분리하기에도 애매해서 그냥 했다.
- 두 구슬의 x좌표, y좌표를 각각 비교하여 어떤 구슬을 먼저 움직일지 결정한다!
  - 예를 들어, 판을 오른쪽으로 기울일 때에는 더 오른쪽에 있는(x좌표가 더 큰) 구슬을 먼저 움직인다.
- 그리고 움직이는 순서에 따라 상태 판단도 달라진다.
  - 빨간 구슬이 먼저 움직였다면, 빨간 구슬이 구멍에 들어가면서 파란 구슬이 구멍에 안 들어가는것을 확인해야한다.
  - 반대로, 파란 구슬이 먼저 움직였다면, 파란 구슬이 구멍에 들어가지 않은 상태이면서 빨간 구슬이 들어갔는지를 확인해야 한다.
- 중간에 디버깅이 필요했던 부분
  - 구슬의 위치에 대해 분기할때 초기 위치로만 확인해서 문제가 틀렸었다.
- 판을 어떻게 움직일지에 대해서는, 10번만 움직이면 되고, 4방향으로만 기울일 수 있으므로 비트를 사용했다.
  - 위로 기울일때를 00, 아래로 기울일때를 01, 왼쪽으로 기울일때를 10, 오른쪽으로 기울일때를 11로 두개의 비트로 표현 가능하다.
  - 최대 2x10=20비트만을 사용해서 트래킹을 할 수 있다.
  - 따라서 상태를 저장할 때 2비트씩 왼쪽으로 shift 연산하고, 방향 숫자를 or 연산하여 저장했다.
  - 빨간 구슬만 탈출시키기를 성공했을 때는 오른쪽으로 2비트씩 넘기면서 어떻게 움직였었는지를 역순으로 확인할 수 있다.

