### PR TITLE
[240513] BOJ 18223 민준이와 마산 그리고 건우

### DIFF
--- a/u1qns/Week_16/BOJ_18223_민준이와 마산 그리고 건우.java
+++ b/u1qns/Week_16/BOJ_18223_민준이와 마산 그리고 건우.java
@@ -1,0 +1,105 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    final static int INF = Integer.MAX_VALUE;
+
+    static BufferedReader br;
+    static StringTokenizer st;
+
+    static int V, E, P;
+    static class Info
+    {
+        public Info(int vertex, boolean isSave, int sum) {
+            this.vertex = vertex;
+            this.isSave = isSave;
+            this.sum = sum;
+        }
+
+        int vertex;
+        int sum;
+        boolean isSave = false;
+    }
+
+    static boolean solve(final int start, final int end) throws IOException
+    {
+        boolean answer = false;
+
+        List<List<int[]>> graph = new ArrayList<>();
+        for (int i = 0; i < 5001; ++i)
+            graph.add(new ArrayList<>());
+
+        int from, to, c;
+        for (int i = 0; i < E; ++i)
+        {
+            st = new StringTokenizer(br.readLine());
+            from = Integer.parseInt(st.nextToken());
+            to = Integer.parseInt(st.nextToken());
+            c = Integer.parseInt(st.nextToken());
+            graph.get(from).add(new int[]{to, c});
+            graph.get(to).add(new int[]{from, c});
+        }
+
+        int[] dp = new int[V + 1];
+        Arrays.fill(dp, INF);
+        dp[1] = 0;
+
+        PriorityQueue<Info> q = new PriorityQueue<>((a, b) -> Integer.compare(a.sum, b.sum));
+        for (final int[] node : graph.get(start))
+        {
+            q.add(new Info(node[0], node[0] == P, node[1]));
+        }
+
+        Info front;
+        int minValue = INF;
+        while (!q.isEmpty())
+        {
+            front = q.poll();
+            if(front.sum > minValue) break;
+            if(front.vertex == end)
+            {
+                minValue = front.sum;
+                //minValue = dp[end];
+                if(front.isSave)
+                {
+                    answer = true;
+                    break;
+                }
+            }
+
+            for (final int[] info : graph.get(front.vertex))
+            {
+                int next = info[0];
+                int cost = info[1];
+
+                // 이미 방문한 곳의 가중치가 더 큰 방법으로 다가가려고 한다. -> continue
+                if (front.sum + cost <= dp[next])
+                {
+                    dp[next] = front.sum + cost;
+                    q.offer(new Info(next, next == P ? true : front.isSave,  dp[next]));
+                }
+            }
+        }
+
+        return answer;
+    }
+
+    public static void main(String[] args) throws IOException {
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine());
+
+        V = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+
+        boolean answer = false;
+        if(P == V || P == 1)
+            answer = true;
+        else
+            answer = solve(1, V);
+
+        System.out.print(answer ? "SAVE HIM" : "GOOD BYE");
+    } // main
+}


### PR DESCRIPTION
## 이슈넘버
#412 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/78313597)

## 소요시간
200분

## 알고리즘
다익스트라

## 풀이
전형적인 다익스트라 문제.
특이한 점은 최소 경로에 P라는 친구가 경로에 존재하는지 확인하는거다. 

처음에는 다익스트라의 역경로인가 했는데 또 다시 역행하는 것에 대한 시간 우려 때문에 접근법을 바꾸었다. 
그래서 다익스트라에서 사용하는 노드에 P가 있는지 boolean으로 데리고 다니는 방법을 선택했다. 
1->P 와 P-> V 그리고 1->V를 비교하는 시간보다 나은지 다른 사람 시간을 보고 싶다!


---
**68% 틀렸던 이유**

![image](https://github.com/BE-Archive/Algorithm-Study/assets/85053365/b15524fb-0479-4664-9bb8-f09a44131aaa)

### 변경 사항
```
dp[front.vertext] 와 front.sum의 차이
```


**[오답]**
```java
for (final int[] info : graph.get(front.vertex))
{
    int next = info[0];
    int cost = info[1];

    if (dp[front.vertex] + cost <= dp[next]) // 여기
    {
        dp[next] = dp[front.vertex] + cost; // 여기
        q.offer(new Info(next, next == P ? true : front.isSave,  dp[next]));
    }
}
```
if문을 보면 현재 노드의 dp값 (최소 방문)을 이용하는 것이 문제였다. 
서로 경로가 다른 상태에서 현재 노드의 경로로만 도달했을 때 가중치를 사용해야한다.

**[정답]**
```java
for (final int[] info : graph.get(front.vertex))
{
    int next = info[0];
    int cost = info[1];

    if (front.sum + cost <= dp[next]) // 여기
    {
        dp[next] = front.sum + cost; // 여기
        q.offer(new Info(next, next == P ? true : front.isSave,  dp[next]));
    }
}
```