### PR TITLE
[240517] BOJ 2638 치즈

### DIFF
--- a/u1qns/Week_17/BOJ_2638_치즈.cpp
+++ b/u1qns/Week_17/BOJ_2638_치즈.cpp
@@ -1,0 +1,89 @@
+#include <iostream>
+#include <queue>
+#define MAX 101
+
+typedef std::pair<int, int> pii;
+
+const int dx[4] = {1, -1, 0, 0};
+const int dy[4] = {0, 0, 1, -1};
+
+int N, M, totalCheese = 0;
+
+int arr[MAX][MAX], counter[MAX][MAX] = {0, };
+bool visited[MAX][MAX] = {false, };
+
+bool isValid(const int x, const int y)
+{
+    if(x<0 || x>=N || y<0 ||y>=M)
+        return false;
+    return true;
+}
+
+std::queue<pii> melt(std::queue<pii>& air)
+{
+    std::queue<pii> cheese;
+    
+    pii front;
+    while(!air.empty())
+    {
+        front = air.front(); air.pop();
+        for(int d=0; d<4; ++d)
+        {
+            int x = front.first + dx[d];
+            int y = front.second + dy[d];
+
+            if(!isValid(x, y) || visited[x][y]) continue;
+
+            if(arr[x][y])
+            {
+                if(++counter[x][y] > 1)
+                {
+                    --totalCheese;
+                    visited[x][y] = true;
+                    cheese.push(std::make_pair(x, y));
+                }
+            }
+            else
+            {
+                visited[x][y] = true;
+                air.push(std::make_pair(x, y));
+            }
+        }
+    }
+    return cheese;
+}
+
+int solve()
+{
+    int answer = 0;
+
+    std::queue<pii> air;
+    air.push(std::make_pair(0, 0));
+
+    while(totalCheese)
+    {
+        ++answer;
+        air = melt(air);
+        //show();
+    }
+
+    return answer;
+}
+
+int main()
+{
+    std::cin >> N >> M;
+
+    for(int i=0; i<N; ++i)
+    {
+        for(int j=0; j<M; ++j)
+        {
+            std::cin >> arr[i][j];
+            if(arr[i][j]) ++totalCheese;
+        }
+    }
+
+    std::cout << solve();
+
+    return 0;
+}


### PR DESCRIPTION
## 이슈넘버
#420 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/78500908)


## 소요시간
50분

## 알고리즘
BFS

## 풀이

오랜만에 문제 정리

**[상태]**
N x M 맵 (100 x 100)
- 치즈 1
- 공기 0

**[동작]**
치즈 녹이기 
 - (1) 치즈와 상하좌우로 맞닿아있는 공기가 2개 이상일 경우에만 녹는다. 
 - (2) 치즈로 둘러 쌓인 내부의 공기는 치즈를 녹일 수 없다 - 문제 그림 참고
 
간단하게 생각해낸 큰 틀은 아래와 같다. 
```cpp
while(totalCheese) // 모든 치즈가 녹을 때까지
{
    ++answer; // 걸린 시간
    melt() // 치즈를 녹여보자. 
}
```

일단 "한칸"씩 치즈가 녹으니 BFS가 적합한 알고리즘이라고 판단했다.
이제 세부조건 맞춰주기 전에 생각을 해보자. 
맵의 상태가 2개이기 때문에 queue에 넣을 수 있는 것도 2개다. 

**(1) 치즈 기준으로 bfs를 돈다.**
해당하는 치즈가 녹을 수 있는지 사방 탐색을 해야한다. 
- 한셀마다 사방탐색을 하면, 사방탐색하는 부분이 중복되기 때문에 비효율이다.
- 만약 시간이 된다고 하더라도, 치즈와 맞닿은 공기가 내부에 있는 공기인지 확인하기 힘들다. -> 조건 (2) 충족 X 

**(2) 공기 기준으로 bfs를 돈다.**
문제에서 아래에 이런 문장이 있어서 사실 문제에서 알려주고 있다. 👍 
``
모눈종이의 맨 가장자리에는 치즈가 놓이지 않는 것으로 가정한다. 
``



가장 자리 아무거나 (0, 0) 먼저 큐에 넣어서 공기들을 다 visited 처리해주자. 
자연스럽게 치즈로 둘러 쌓여 버린 공기는 치즈에 막혀서 만날 수 없다. -> 조건 (2) 충족 O

조건 (1)을 충족 시키기 위해서 counter[][]을 선언해주었다.
공기로 탐색을 하다가 치즈를 만나면 공기랑 만났다고 ++counter를 해준다. 
그리고 제거 조건 counter == 2가 되면, 녹이고 다른 queue에 넣어준다. 

치즈가 녹으면 그 자리는 다시 공기가 차지하게 된다. 
치즈가 녹은 위치가 다음번에 탐색할 공기들의 위치로 다시 재지정을 해준다. 
이렇게 하면 다시 가장자리부터 치즈까지 닿기 위한 queue를 돌지 않아도 된다. 

```cpp
while(totalCheese)
{
        ++answer;
        air = melt(air); // 녹은 치즈의 위치를 담은 queue 반환
}
```

---
메모리 1000대가 있던데.. 어떻게 한걸까?...  난 몇번을 고쳐도 2024가 최선이다..

