### PR TITLE
[240529] BOJ 17780 새로운 게임

### DIFF
--- a/trankill1127/w19/BOJ_17780.java
+++ b/trankill1127/w19/BOJ_17780.java
@@ -1,0 +1,174 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+public class BOJ_17780 {
+
+    public static class Piece {
+        int id;
+        int direction;
+
+        public Piece(int id, int direction) {
+            this.id = id;
+            this.direction = direction;
+        }
+    }
+
+    public static class Cell implements Comparable<Cell>{
+        int x;
+        int y;
+        ArrayList<Piece> pieces = new ArrayList<>();
+
+        public Cell(int x, int y, int id, int dir) {
+            this.x = x;
+            this.y = y;
+            this.pieces.add(new Piece(id, dir));
+        }
+
+        @Override
+        public int compareTo(Cell o) {
+            return this.pieces.get(0).id - o.pieces.get(0).id;
+        }
+    }
+
+    public static int[][] dir = {
+            {0, 1}, //오른쪽
+            {0, -1}, //왼쪽
+            {-1, 0}, //위쪽
+            {1, 0} //아래쪽
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine().trim());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        int[][] board = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine().trim());
+            for (int j = 0; j < n; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        //0: 흰      1: 빨      2: 파
+
+        LinkedList<Cell> cells = new LinkedList<>();
+        for (int i = 1; i <= k; i++) {
+            st = new StringTokenizer(br.readLine().trim());
+
+            int x = Integer.parseInt(st.nextToken()) - 1;
+            int y = Integer.parseInt(st.nextToken()) - 1;
+            int d = Integer.parseInt(st.nextToken()) - 1;
+
+            cells.add(new Cell(x, y, i, d));
+        }
+
+        int turnCnt = 0;
+
+        outer:
+        while (true) {
+
+            turnCnt++;
+
+            //모든 그룹을 가장 아래에 있는 기물의 id 기준 오름차순으로 정렬한다.
+            Collections.sort(cells);
+
+            //모든 그룹을 검사한다.
+            for (int i = 0; i < cells.size(); i++) {
+
+                Cell curCell = cells.get(i);
+
+                int[] nextPos = new int[]{
+                        curCell.x + dir[curCell.pieces.get(0).direction][0],
+                        curCell.y + dir[curCell.pieces.get(0).direction][1]
+                };
+
+                if (nextPos[0] < 0 || nextPos[0] >= n || nextPos[1] < 0 || nextPos[1] >= n || board[nextPos[0]][nextPos[1]] == 2) { //파
+
+                    if (curCell.pieces.get(0).direction == 0) {
+                        curCell.pieces.get(0).direction = 1;
+                    } else if (curCell.pieces.get(0).direction == 1) {
+                        curCell.pieces.get(0).direction = 0;
+                    } else if (curCell.pieces.get(0).direction == 2) {
+                        curCell.pieces.get(0).direction = 3;
+                    } else {
+                        curCell.pieces.get(0).direction = 2;
+                    }
+
+                    nextPos[0] = curCell.x + dir[curCell.pieces.get(0).direction][0];
+                    nextPos[1] = curCell.y + dir[curCell.pieces.get(0).direction][1];
+                    if (nextPos[0] < 0 || nextPos[0] >= n || nextPos[1] < 0 || nextPos[1] >= n || board[nextPos[0]][nextPos[1]] == 2) {
+                        continue;
+                    } else {
+                        i--;
+                        continue;
+                    }
+
+                }
+
+                //이동할 칸의 색상을 확인한다.
+                else if (board[nextPos[0]][nextPos[1]] == 0) { //흰
+
+                    boolean isThere = false;
+                    for (int j = 0; j < cells.size(); j++) {
+                        if (cells.get(j).x == nextPos[0] &&
+                                cells.get(j).y == nextPos[1]) {
+                            isThere = true;
+
+                            if ((curCell.pieces.size() + cells.get(j).pieces.size()) >= 4) {
+                                break outer;
+                            }
+
+                            cells.get(j).pieces.addAll(curCell.pieces);
+                            curCell.pieces.clear();
+                            break;
+                        }
+                    }
+                    if (!isThere) {
+                        curCell.x = nextPos[0];
+                        curCell.y = nextPos[1];
+                    }
+
+                } else if (board[nextPos[0]][nextPos[1]] == 1) { //빨
+
+                    boolean isThere = false;
+                    for (int j = 0; j < cells.size(); j++) {
+                        if (cells.get(j).x == nextPos[0] &&
+                                cells.get(j).y == nextPos[1]) {
+                            isThere = true;
+
+                            if ((curCell.pieces.size() + cells.get(j).pieces.size()) >= 4) {
+                                break outer;
+                            }
+
+                            for (int cIdx = curCell.pieces.size() - 1; cIdx >= 0; cIdx--) {
+                                cells.get(j).pieces.add(curCell.pieces.get(cIdx));
+                            }
+                            curCell.pieces.clear();
+                            break;
+                        }
+                    }
+                    if (!isThere) {
+                        curCell.x = nextPos[0];
+                        curCell.y = nextPos[1];
+                        ArrayList<Piece> reversedPieces = new ArrayList<>(curCell.pieces);
+                        Collections.reverse(reversedPieces);
+                        curCell.pieces = reversedPieces;
+                    }
+
+                }
+
+            }
+
+        }
+
+        System.out.println(turnCnt);
+
+    }
+}


### PR DESCRIPTION
## 이슈넘버
#463 

## 소스코드
[코드 링크](https://www.acmicpc.net/source/79028349)

## 소요시간
3시간

## 알고리즘
구현

## 풀이
경우의 수는 크게 6가지로 나눌 수 있다.

#### 1. 이동할 위치가 흰색 타일인 경우
- 이동할 위치가 비어있지 않은 경우
- 이동할 위치가 비어있는 경우
#### 2. 이동할 위치가 빨간색 타일인 경우
- 이동할 위치가 비어있지 않은 경우
- 이동할 위치가 비어있는 경우 
#### 3. 이동할 위치가 파란색 타일인 경우
- 방향을 바꾼 후 이동할 위치가 파란색 타일인 경우
- 방향을 바꾼 후 이동할 위치가 파란색 타일이 아닌 경우

잘 살펴보면 어떤 경우에도 한번 합쳐진 기물들은 분리되지 않는다.
또한, 이동의 기준점이 되는 맨 아래 기물이 바뀌는 경우는 이동할 위치가 빨간색 타일이고 비어있는 때 뿐이라는 것도 알 수 있다.

나는 아래와 같이 Cell이라는 클래스를 만들었다.
```
public static class Cell implements Comparable<Cell>{
        int x;
        int y;
        ArrayList<Piece> pieces;

        public Cell(int x, int y, int id, int  dir) {
            this.x = x;
            this.y = y;
            this.pieces=new ArrayList<>();
            this.pieces.add(new Piece(id, dir));
        }

        @Override
        public int compareTo(Cell o) {
            return this.pieces.get(0).id - o.pieces.get(0).id;
        }
    }
```
좌표와 그 좌표에 있는 기물들로 구성했는데 이동할 위치에 있는 다른 그룹과 합칠 때 `addAll`과 `remove`로 간단하게 합칠 수 있고, 그룹의 순서를 뒤집어야 할 때도 `Collections.reverse`를 사용할 수 있기 때문에 편리하다.

이동의 기준점이 되는 맨 아래 기물이 바뀔 때는 그룹이 순서대로 검사받을 수 있게 정렬을 다시 하고 검사할 그룹을 다시 찾아주면 된다.

나머지 구현에 대한 설명은 코드에 주석으로 적어두었다.