### PR TITLE
[240602] BOJ 21278 호석이 두 마리 치킨

### DIFF
--- a/trankill1127/w19/BOJ_21278.java
+++ b/trankill1127/w19/BOJ_21278.java
@@ -47,9 +47,8 @@ public class BOJ_21278 {
             for (int j=i+1; j<=n; j++) { //B
 
                 int len=0;
-                for (int k=1; k<=n; k++){
+                for (int k=1; k<=n; k++)
                     len += Math.min(board[i][k], board[j][k]);
-                }
 
                 if (minLen>len) {
                     l=i; r=j; minLen=len;


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#504 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/79137738)

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
50분

## 알고리즘
<!---- 문제 풀이에 사용된 알고리즘을 작성해 주세요 -->
플로이드 워셜

## 풀이
<!---- 여기서부터는 자유롭게 작성하시면 됩니다.-->
치킨집을 세울 건물 A, B를 골라야 하며, 모든 건물이 치킨집에 갈 수 있는 최단경로의 합*2를 구해서 출력해야 한다.

어차피 모든 경우를 따져봐야 할 것 같아서 모든 정점 쌍의 최단경로를 구할 수 있는 플로이드 워셜 알고리즘을 사용했다.

그 후에 정점 쌍을 임으로 정하고 그 경우에 치킨집까지 가는 최단경로의 합을 구했다.
건물이 5개 인 경우 5C2개의 정점 쌍, 최단경로의 합을 구할 수 있는데 이 중에서 최소의 최단경로의 합을 갖는 것을 출력하였다.