### PR TITLE
[240605] BOJ 1756 피자 굽기

### DIFF
--- a/hyunseok0314/Week_19/BOJ_1756_피자_굽기.java
+++ b/hyunseok0314/Week_19/BOJ_1756_피자_굽기.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1756_피자_굽기 {
+
+    static int D, N;
+    static int[] oven, dough;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        D = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+
+        oven = new int[D + 1];
+        dough = new int[N];
+
+        int min = Integer.MAX_VALUE;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= D; i++) {
+            min = Math.min(min, Integer.parseInt(st.nextToken()));
+            oven[i] = min;
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            dough[i] = Integer.parseInt(st.nextToken());
+        }
+
+        end: for (int d : dough) {
+            while (oven[D--] < d) {
+                if (D < 0) {
+                    break end;
+                }
+            }
+        }
+
+        System.out.println(D + 1);
+    }
+}


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
#519 

## 소스코드
```java
import java.io.BufferedReader;
import java.io.InputStreamReader;
import java.util.StringTokenizer;

public class BOJ_1756_피자_굽기 {

    static int D, N;
    static int[] oven, dough;

    public static void main(String[] args) throws Exception {
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        StringTokenizer st = new StringTokenizer(br.readLine());
        D = Integer.parseInt(st.nextToken());
        N = Integer.parseInt(st.nextToken());

        oven = new int[D];
        dough = new int[N];

        int min = Integer.MAX_VALUE;
        st = new StringTokenizer(br.readLine());
        for (int i = 0; i < D; i++) {
            min = Math.min(min, Integer.parseInt(st.nextToken()));
            oven[i] = min;
        }

        st = new StringTokenizer(br.readLine());
        for (int i = 0; i < N; i++) {
            dough[i] = Integer.parseInt(st.nextToken());
        }

        end: for (int d : dough) {
            while (oven[D--] < d) {
                if (D < 0) {
                    break end;
                }
            }
        }

        System.out.println(D + 1);
    }
}
```

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
80분

## 알고리즘
애드 혹

## 풀이
작은 지름 뒤에 큰 지름이 와도 먼저 입력 받은 작은 지름의 반죽밖에 들어올 수 없기 때문에 입력 받을 때 입력 받은 지름들 중에 가장 작은 값으로 설정하였습니다. 그 후 오븐의 밑바닥부터 차례로 비교하며 반죽의 위치를 찾았습니다. 시간이 오래 걸린 이유는 마지막 반죽이 맨 위에 올라오는 경우와 반죽이 오븐에 들어가지 못하는 경우를 구분하지 않아서 디버깅하는데 시간이 오래 걸렸습니다. 
