### PR TITLE
[240605] BOJ 1756 피자 굽기

### DIFF
--- a/seoyoung059/Week_20/BOJ_1756/BOJ_1756.java
+++ b/seoyoung059/Week_20/BOJ_1756/BOJ_1756.java
@@ -1,0 +1,47 @@
+package Week_20.BOJ_1756;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1756 {
+
+
+    static int lower_bound(int[] oven, int start, int dough) {
+        int end = oven.length - 1, mid;
+        while (start < end) {
+            mid = (start + end) / 2;
+            if (oven[mid] < dough) {
+                start = mid + 1;
+            } else {
+                end = mid;
+            }
+        }
+        return end;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int d = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+
+        int[] oven = new int[d + 1];
+        st = new StringTokenizer(br.readLine());
+        oven[d] = Integer.MAX_VALUE;
+        for (int i = d - 1; i >= 0; i--) {
+            oven[i] = Math.min(Integer.parseInt(st.nextToken()), oven[i + 1]);
+        }
+
+
+        int start = -1;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            start = lower_bound(oven, start + 1, Integer.parseInt(st.nextToken()));
+        }
+
+        System.out.println(d - start);
+    }
+}

--- a/seoyoung059/Week_20/BOJ_1756/BOJ_1756.md
+++ b/seoyoung059/Week_20/BOJ_1756/BOJ_1756.md
@@ -1,0 +1,56 @@
+## 문제풀이
+- 오븐의 윗쪽이 작으면 아랫쪽의 지름이 넓어지더라도 큰 반죽이 들어갈 수 없다.
+- 따라서 오븐의 윗쪽부터 지름을 받을 때, 앞쪽의 최솟값과 지름을 비교하여 값을 저장해야 한다.
+- 이렇게 하면 오븐의 지름 배열이 오름차순이 되기 때문에, 이진탐색으로 각 반죽이 어디에 위치하게 되는지 차례대로 확인할 수 있다.
+
+## 코드
+```java
+package Week_20.BOJ_1756;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1756 {
+
+
+    static int lower_bound(int[] oven, int start, int dough) {
+        int end = oven.length - 1, mid;
+        while (start < end) {
+            mid = (start + end) / 2;
+            if (oven[mid] < dough) {
+                start = mid + 1;
+            } else {
+                end = mid;
+            }
+        }
+        return end;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int d = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+
+        int[] oven = new int[d + 1];
+        st = new StringTokenizer(br.readLine());
+        oven[d] = Integer.MAX_VALUE;
+        for (int i = d - 1; i >= 0; i--) {
+            oven[i] = Math.min(Integer.parseInt(st.nextToken()), oven[i + 1]);
+        }
+
+
+        int start = -1;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            start = lower_bound(oven, start + 1, Integer.parseInt(st.nextToken()));
+        }
+
+        System.out.println(d - start);
+    }
+}
+
+```


### PR DESCRIPTION
## 이슈넘버
#519 

## 소스코드
```java
package Week_20.BOJ_1756;

import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;
import java.util.StringTokenizer;

public class BOJ_1756 {

    // lower bound로 주어지는 반죽의 크기보다 같거나 큰 것중 가장 왼쪽에 있는 것을 찾음
    static int lower_bound(int[] oven, int start, int dough) {
        int end = oven.length - 1, mid;
        while (start < end) {
            mid = (start + end) / 2;
            if (oven[mid] < dough) {
                start = mid + 1;
            } else {
                end = mid;
            }
        }
        return end;
    }

    public static void main(String[] args) throws IOException {
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        StringTokenizer st = new StringTokenizer(br.readLine());

        int d = Integer.parseInt(st.nextToken());
        int n = Integer.parseInt(st.nextToken());

        int[] oven = new int[d + 1];
        st = new StringTokenizer(br.readLine());
        oven[d] = Integer.MAX_VALUE;  // 가장 아랫쪽은 max val로 두어  Math.min 연산에 영향이 없도록 하였다.
        for (int i = d - 1; i >= 0; i--) {
            oven[i] = Math.min(Integer.parseInt(st.nextToken()), oven[i + 1]);
        }


        int start = -1;
        st = new StringTokenizer(br.readLine());
        for (int i = 0; i < n; i++) {
            start = lower_bound(oven, start + 1, Integer.parseInt(st.nextToken()));
        }

        System.out.println(d - start);
    }
}

```

## 소요시간
60분

## 알고리즘
이진탐색


## 풀이
- 오븐의 윗쪽이 작으면 아랫쪽의 지름이 넓어지더라도 큰 반죽이 들어갈 수 없다.
- 따라서 오븐의 윗쪽부터 지름을 받을 때, 앞쪽의 최솟값과 지름을 비교하여 값을 저장해야 한다.
- 이렇게 하면 오븐의 지름 배열이 오름차순이 되기 때문에, 이진탐색으로 각 반죽이 어디에 위치하게 되는지 차례대로 확인할 수 있다.

