### PR TITLE
[240605] BOJ 1756 피자 굽기

### DIFF
--- a/trankill1127/w20/BOJ_1756.java
+++ b/trankill1127/w20/BOJ_1756.java
@@ -1,0 +1,33 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1756 {
+    public static int[] oven;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine().trim());
+        int d = Integer.parseInt(st.nextToken()); //오븐 깊이
+        int n = Integer.parseInt(st.nextToken()); //피자 반죽 개수
+
+        oven = new int[d+1];
+        st = new StringTokenizer(br.readLine().trim());
+        oven[0]=Integer.MAX_VALUE;
+        for (int i=1; i<=d; i++){
+            oven[i]=Math.min(Integer.parseInt(st.nextToken()), oven[i-1]);
+        }
+
+        st = new StringTokenizer(br.readLine().trim());
+        int bottom=d;
+        for (int i=0; i<n; i++){
+            int cur = Integer.parseInt(st.nextToken());
+            while (bottom>=0 && cur>oven[bottom--]);
+        }
+
+        System.out.println(bottom+1);
+    }
+
+}


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#519 

## 소스코드
<!---- 소스코드를 작성하거나, 링크해주세요. 예시처럼 코드를 링크하거나 MD코드 올리시면 됩니다.-->
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/79293503)

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
2시간 30분

## 알고리즘
<!---- 문제 풀이에 사용된 알고리즘을 작성해 주세요 -->
그리디

## 풀이
<!---- 여기서부터는 자유롭게 작성하시면 됩니다.-->
depth가 2일 때 오븐의 지름이 depth가 1일 때의 지름보다 크다면 depth가 1일 때 반죽이 걸쳐서 2까지 내려오지 못한다. 이 점을 이용해서 오븐의 깊이 별 지름을 오름차순으로 만들 수 있다. 
그리고 반죽이 어느 깊이에서 걸치는지 입력 순으로 계산해주면 답을 구할 수 있다.