### PR TITLE
[240610] BOJ 3980 선발 명단

### DIFF
--- a/trankill1127/w21/BOJ_3980.java
+++ b/trankill1127/w21/BOJ_3980.java
@@ -6,12 +6,14 @@ import java.util.StringTokenizer;
 public class BOJ_3980 {
 
     static int[][] board = new int[11][11];
+    static boolean[] position = new boolean[11];
     public static int maxTotScore=0;
 
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = null;
         StringBuilder sb = new StringBuilder();
+
         int c = Integer.parseInt(br.readLine());
         while (c>0){
             for (int i=0; i<11; i++) {
@@ -22,14 +24,15 @@ public class BOJ_3980 {
                 }
             }
             maxTotScore=0;
-            recursive(0,0, new boolean[11]);
+            position = new boolean[11];
+            recursive(0,0);
             sb.append(maxTotScore).append("\n");
             c--;
         }
         System.out.println(sb.toString());
     }
 
-    public static void recursive(int player, int totScore, boolean[] position){
+    public static void recursive(int player, int totScore){
         if (player==11){
             maxTotScore = Math.max(maxTotScore, totScore);
             return;
@@ -38,7 +41,7 @@ public class BOJ_3980 {
         for (int pos=0; pos<11; pos++){
             if (position[pos] || board[player][pos]==0) continue;
             position[pos]=true;
-            recursive(player+1, totScore+board[player][pos], position);
+            recursive(player+1, totScore+board[player][pos]);
             position[pos]=false;
         }
 

--- a/trankill1127/w21/BOJ_3980.java
+++ b/trankill1127/w21/BOJ_3980.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_3980 {
+
+    static int[][] board = new int[11][11];
+    public static int maxTotScore=0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = null;
+        StringBuilder sb = new StringBuilder();
+        int c = Integer.parseInt(br.readLine());
+        while (c>0){
+            for (int i=0; i<11; i++) {
+                st = new StringTokenizer(br.readLine().trim());
+                for (int j = 0; j < 11; j++) {
+                    board[i][j] = Integer.parseInt(st.nextToken());
+
+                }
+            }
+            maxTotScore=0;
+            recursive(0,0, new boolean[11]);
+            sb.append(maxTotScore).append("\n");
+            c--;
+        }
+        System.out.println(sb.toString());
+    }
+
+    public static void recursive(int player, int totScore, boolean[] position){
+        if (player==11){
+            maxTotScore = Math.max(maxTotScore, totScore);
+            return;
+        }
+
+        for (int pos=0; pos<11; pos++){
+            if (position[pos] || board[player][pos]==0) continue;
+            position[pos]=true;
+            recursive(player+1, totScore+board[player][pos], position);
+            position[pos]=false;
+        }
+
+    }
+}


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#539 

## 소스코드
<!---- 소스코드를 작성하거나, 링크해주세요. 예시처럼 코드를 링크하거나 MD코드 올리시면 됩니다.-->
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/79475068)

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
40분

## 알고리즘
백트랙킹

## 풀이
우선순위 큐로 풀어보려다 12퍼 틀의 벽에 부딫혀서 그냥 백트랙킹으로 풀었다.

### 우선순위 큐로 왜 안 풀렸는가?
선수, 포지션, 성적을 담을 수 있고, 성적 내림차순으로 정렬이 되는 우선순위 큐를 만들었다.
우선순위 큐에서 하나씩 꺼내서 

1) 아무도 이 포지션을 차지하지 않았고 
2) 이 선수가 다른 포지션에 이미 지정된 게 아니면  

totScore에 성적을 추가하는 방식으로 구현했다.

#### 근데 이러면 문제가 되는 상황은 아래와 같다. 

**1번 선수**가 포지션1 90점, 포지션2 70점이다.
**2번 선수**가 포지션1 50점이다.
**나머지 선수들**은 포지션1, 2와 무관하다.

이때 **1번 선수**가 포지션1을 먼저 차지하게 되면 **2번 선수**는 유일하게 자신이 갈 수 있던 포지션을 잃어버리고 어떤 포지션에도 배치받지 못하는 상황이 발생하게 된다.

이걸 해소할 방법이 떠오르지 않아서 다른 풀이를 생각하게 되었고 그게 백트랙킹이었다.