### PR TITLE
[240620] BOJ 2170 선 긋기

### DIFF
--- a/u1qns/Week_23/BOJ_2170_선긋기.cpp
+++ b/u1qns/Week_23/BOJ_2170_선긋기.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <algorithm>
+
+typedef std::pair<int, int> pii;
+
+long long getAnswer(std::vector<pii>& line)
+{
+    long long answer = 0;
+
+    std::sort(line.begin(), line.end());
+
+    int start = line[0].first;
+    int end = line[0].second;
+
+    for(auto& [x, y] : line)
+    {
+        if(end < x) 
+        {
+            answer += end - start;
+            start = x;
+        }
+        end = std::max(end, y); // 끝점은 계속 커져야하고
+    }
+
+    return answer + end - start;
+}
+
+int main()
+{
+    std::ios_base::sync_with_stdio(false);
+    std::cin.tie(NULL);
+
+    int N, x, y;
+    std::cin>>N;
+    std::vector<pii> line(N);
+    for(int i=0; i<N; ++i)
+        std::cin >> line[i].first >> line[i].second;
+
+    std::cout << getAnswer(line);
+
+    return 0;
+}


### PR DESCRIPTION
## 이슈넘버
#616 

## 소스코드
```cpp
#include <iostream>
#include <queue>
#include <vector>
#include <algorithm>

typedef std::pair<int, int> pii;

long long getAnswer(std::vector<pii>& line)
{
    long long answer = 0;

    std::sort(line.begin(), line.end());

    int start = line[0].first;
    int end = line[0].second;

    for(const auto& [x, y] : line)
    {
        if(end < x) 
        {
            answer += end - start; // 걸쳐져 있지 않아서 지금까지의 선 길이 저장
            start = x; // 여기서 새로운 선이 시작된다고 침
        }
        end = std::max(end, y); // 끝점은 계속 커져야 함
    }
    return answer + end - start;
}

int main()
{
    std::ios_base::sync_with_stdio(false);
    std::cin.tie(NULL);

    int N, x, y;
    std::cin>>N;
    std::vector<pii> line(N);
    for(int i=0; i<N; ++i)
        std::cin >> line[i].first >> line[i].second;

    std::cout << getAnswer(line);

    return 0;
}
```

## 소요시간
40분

## 알고리즘
정렬

## 풀이
일직선이나열된걸생각해보자. 일직선이 겹쳐진 건 상관하지 않아도 되니까 가장 긴 선의 범위를 가지는 start, end라는 변수를 만든다.
나머지 선들이 start, end의 내부에 있으면 길이는 연장되지 않는다.
만약 선이 서로 걸쳐져있으면 길이를 연장시켜준다. 
선이 겹치지 않으면 겹치지 않았던 길이를 정답에 추가시켜준다. (정렬되어있기 때문에 이렇게 할 수 있다)
