### PR TITLE
[240624] BOJ 2179 비슷한 단어

### DIFF
--- a/u1qns/Week_24/BOJ_2179_비슷한단어.cpp
+++ b/u1qns/Week_24/BOJ_2179_비슷한단어.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <string>
+#include <map>
+#include <queue>
+#include <set>
+
+int main()
+{
+    int N;
+    std::string T;
+    std::vector<std::string> input;
+    std::set<std::string> check;
+
+    //std::priority_queue<std::pair<std::string, int>, std::vector<std::pair<std::string, int>>, std::greater<>> pq;
+    std::map<std::string, std::vector<int>> map;
+    std::cin >> N;
+    input.resize(N);
+
+    int mv = 0;
+    std::string answer;
+
+    for(int i=0; i<N; ++i)
+    {
+        std::cin >>  T;
+        input[i] = T;
+
+        if(check.find(T) != check.end()) continue;
+
+        check.insert(T);
+        std::string tmp="";
+        for(int s=0; s<T.size(); ++s)
+        {
+            tmp += T[s];
+            map[tmp].push_back(i);
+            if(map[tmp].size() >=2 && tmp.size() > mv)
+            {
+                answer = tmp;
+                mv = tmp.size();
+            }
+            else if(map[tmp].size() >=2 && tmp.size() == mv)
+            {
+                if(mv!=0 && answer > tmp)
+                {
+                    answer = tmp;
+                    mv = tmp.size();
+                }
+            }
+        }
+    }
+
+    std::cout << input[map[answer][0]] << "\n";
+    std::cout << input[map[answer][1]] << "\n";
+
+    return 0;
+}

--- a/u1qns/Week_24/BOJ_2179_비슷한단어.cpp
+++ b/u1qns/Week_24/BOJ_2179_비슷한단어.cpp
@@ -1,55 +1,60 @@
 #include <iostream>
 #include <string>
 #include <map>
-#include <queue>
 #include <set>
+#include <vector>
+#include <algorithm>
 
 int main()
 {
-    int N;
+    std::ios_base::sync_with_stdio(false);
+    std::cin.tie(0);
+    
     std::string T;
     std::vector<std::string> input;
     std::set<std::string> check;
-
-    //std::priority_queue<std::pair<std::string, int>, std::vector<std::pair<std::string, int>>, std::greater<>> pq;
     std::map<std::string, std::vector<int>> map;
+
+    int max_length = 0;
+    int max_prefix_order = 1e9;
+    std::string max_prefix;
+    
+    int N;
     std::cin >> N;
     input.resize(N);
-
-    int mv = 0;
-    std::string answer;
-
     for(int i=0; i<N; ++i)
     {
         std::cin >>  T;
         input[i] = T;
 
         if(check.find(T) != check.end()) continue;
-
         check.insert(T);
+
         std::string tmp="";
         for(int s=0; s<T.size(); ++s)
         {
             tmp += T[s];
             map[tmp].push_back(i);
-            if(map[tmp].size() >=2 && tmp.size() > mv)
+
+            if(map[tmp].size() > 1 && max_length < tmp.length())
             {
-                answer = tmp;
-                mv = tmp.size();
-            }
-            else if(map[tmp].size() >=2 && tmp.size() == mv)
-            {
-                if(mv!=0 && answer > tmp)
-                {
-                    answer = tmp;
-                    mv = tmp.size();
-                }
+                max_length = tmp.length();
             }
         }
     }
 
-    std::cout << input[map[answer][0]] << "\n";
-    std::cout << input[map[answer][1]] << "\n";
+    for(const auto& [key, value] : map)
+    {
+        if(value.size() >=2 && key.length() == max_length)
+        {
+            if(value[0] < max_prefix_order)
+            {
+                max_prefix_order = value[0];
+                max_prefix = key;
+            }
+        }
+    }
 
+    std::cout << input[map[max_prefix][0]] << "\n" << input[map[max_prefix][1]];
     return 0;
 }


### PR DESCRIPTION
## 이슈넘버
#641

## 소스코드

```cpp
#include <iostream>
#include <string>
#include <map>
#include <set>
#include <vector>
#include <algorithm>

int main()
{
    std::ios_base::sync_with_stdio(false);
    std::cin.tie(0);
    
    std::string T;
    std::vector<std::string> input;
    std::set<std::string> check;
    std::map<std::string, std::vector<int>> map;

    int max_length = 0;
    int max_prefix_order = 1e9;
    std::string max_prefix;
    
    int N;
    std::cin >> N;
    input.resize(N);
    for(int i=0; i<N; ++i)
    {
        std::cin >>  T;
        input[i] = T;

        if(check.find(T) != check.end()) continue;
        check.insert(T);

        std::string tmp="";
        for(int s=0; s<T.size(); ++s)
        {
            tmp += T[s];
            map[tmp].push_back(i);

            if(map[tmp].size() >= 2)
                max_length = std::max(max_length, tmp.length());
        }
    }

    for(const auto& [key, value] : map)
    {
        if(value.size() >=2 && key.length() == max_length)
        {
            if(value[0] < max_prefix_order)
            {
                max_prefix_order = value[0]; // 가장 긴 것 중에 입력이 가장 빠른 것 찾기
                max_prefix = key;
            }
        }
    }

    std::cout << input[map[max_prefix][0]] << "\n" << input[map[max_prefix][1]];
    return 0;
}
```

## 소요시간
40분

## 알고리즘
자료구조(해쉬맵, 셋)

## 풀이
1. 들어온 문자열이 중복이면 다음 문자열을 입력받는다. 이때 `set<std::string> check`를 이용한다. 이 변수는 오직 중복 체크에만 사용된다. 
3. 문자열을 하나씩 쪼개어서 map에 넣는다. 
  -  이때 쪼개진 문자열을 넣고 입력받은 문자열의 순서를 넣는다. 
  - abc -> {a, ab, abc}
  - ab -> {a, ab}
  - map에는 `{a, {0, 1}}, {ab, {0, 1}}, {abc, {0}} `이렇게 저장된다. 

이렇게 해서 key-value관계 중 value가 2개 이상이고 문자열 길이가 가장 긴 것을 기준으로 고른다 . 
max_prefix의 길이가 같은게 많다면 "입력순"으로 빠른 것을 출력해야 한다. 
그렇기 때문에 모든 입력에 대해 입력 받으면서 max_length를 갱신해놓는다. 

그 후, map에 저장된 [key, value]를 순회하면서 max_length와 길이가 같고, value도 2개 이상 (겹치는게 있는) 단어인지 확인한다. 
map이 입력 순서가 아니라 정렬된 순서를 가진다는 것을 명심하자.
우리는 입력 순서를 알아야 하기 때문에 조건이 만족해도 value[0] 를 확인해 가장 먼저 입력된 prefix로 갱신해준다. 
모든 순회를 마친 후 최종적으로 결정된 prefix를 출력한다. 


틀렸던 이유
---
접근법은 맞았으나 prefix의 길이가 같으면 "입력순"으로 출력한다는 점을 고려하지 않았기 때문이다. 나는 출력할 값을 입력순으로 출력하라는 것만 고려하고 있었다..
