### PR TITLE
[240626] BOJ 2515 전시장

### DIFF
--- a/trankill1127/w23/BOJ_2515.java
+++ b/trankill1127/w23/BOJ_2515.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ_2515 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine().trim());
+        int  n = Integer.parseInt(st.nextToken());
+        int  s = Integer.parseInt(st.nextToken());
+
+        List<int[]> drawings = new ArrayList<>();
+        for (int i=0; i<n; i++){
+            st = new StringTokenizer(br.readLine().trim());
+            drawings.add(new int[]{Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())});
+        }
+
+        drawings.sort(new Comparator<int[]>() {
+            @Override
+            public int compare(int[] o1, int[] o2) {
+                if (o1[0] == o2[0]){
+                    return o1[1]-o2[1];
+                }
+                return o1[0] - o2[0];
+            }
+        });
+
+        int[][] dp = new int[n][2];
+        dp[0][1]= drawings.get(0)[1];
+
+        for (int i=1; i<n; i++){
+            dp[i][0]=Math.max(dp[i-1][1], dp[i-1][0]);
+            dp[i][1]=drawings.get(i)[1];
+
+            int start=0, end=n-1, mid=0;
+            while (start<=end){
+                mid=(start+end)/2;
+                if (drawings.get(i)[0] - drawings.get(mid)[0] >= s
+                && drawings.get(i)[0] - drawings.get(mid+1)[0] < s ){
+                    break;
+                }
+                else if (drawings.get(i)[0] - drawings.get(mid)[0] >= s
+                        && drawings.get(i)[0] - drawings.get(mid+1)[0] >= s ){
+                    start=mid+1;
+                }
+                else if (drawings.get(i)[0] - drawings.get(mid)[0] < s){
+                    end=mid-1;
+                }
+            }
+            if (drawings.get(i)[0] - drawings.get(mid)[0] >=s){
+                dp[i][1]+=Math.max(dp[mid][0], dp[mid][1]);
+            }
+        }
+
+        System.out.println(Math.max(dp[n-1][0], dp[n-1][1]));
+    }
+}


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#652 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/80127533)

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
2시간

## 알고리즘
<!---- 문제 풀이에 사용된 알고리즘을 작성해 주세요 ->
DP, **이분탐색**

## 풀이
<!---- 여기서부터는 자유롭게 작성하시면 됩니다.-->
DP각이 선명하길래 그걸로 풀다가 두번째 예제 결과가 이상하게 나오길래 그리디로 다시 생각해보았다. 그런데 도무지 안 풀리길래 분류를 봤는데 DP가 맞더라...! 

나는 그림의 개수가 워낙 많으니 일일히 검사하면 터진다는 생각에 꽂혀서 `i`를 `i-1, i-2`랑만 비교했는데
이분탐색을 하면 이 부분을 해결할 수 있었다...^^

이분탐색으로 `i`번 그림과 `s`이상 차이가 나는 가장 작은 그림 `mid`를 찾아서 그 위치일때 dp[mid][0], dp[mid][1] 중 큰 것을 선택해서 dp[i][1]을 갱신하면 되는 것이었다. 

하자만 이분탐색을 할 때 주의할 점이 있다!
바로 mid의 값이 무조건 크기 차이가 s 이상인 그림의 위치를 저장하는 건 아니라는 점이다. `start<=end`일 때 종료되다 보니 그냥 아무 상관없는 값이 `mid`가 될 수도 있다. 이때를 대비해서 `i`를 세팅한 직후 dp[i][1]를 `i`번째 그림의 가격으로 초기화를 해줘야 한다.