### PR TITLE
[240708] BOJ 1938 통나무 옮기기

### DIFF
--- a/u1qns/Week_25/BOJ_1938_통나무옮기기.cpp
+++ b/u1qns/Week_25/BOJ_1938_통나무옮기기.cpp
@@ -14,7 +14,7 @@ bool grid[MAX][MAX] = {false, };
 bool isValid(const int x, const int y)
 {
     if(x < 0 || y < 0 || x >= N || y >= N || grid[x][y])
-      return false;
+        return false;
     return true;
 }
 
@@ -38,7 +38,7 @@ int bfs()
     int answer = 0;
     Node dest = {(end[0].first == end[1].first), end[1].first, end[1].second};
 
-    std::queue<Node> q; // 통나무의 가로 세로 여부와 통나무 중앙 위치를 중심으로 저장
+    std::queue<Node> q;
     q.push({(start[0].first == start[1].first), start[1].first, start[1].second});
 
     bool visited[2][MAX][MAX] = {false, };
@@ -47,122 +47,53 @@ int bfs()
     while(!q.empty())
     {
         int qSize = q.size();
+        ++answer;
         while(qSize--)
         {
-            const int d = q.front().d;
-            const int x = q.front().x;
-            const int y = q.front().y;
-
-            if(isDone(q.front(), dest))
-                return answer;
+            int mx = q.front().x; int my = q.front().y;
+            int isHorizontal = q.front().d;
 
             q.pop();
 
-            if (!d) // 통나무가 세워져있음
+            int fx = (isHorizontal ? mx : mx-1 ); int fy = (isHorizontal ? my-1 : my);
+            int lx = (isHorizontal ? mx : mx+1 ); int ly = (isHorizontal ? my+1 : my);
+
+            for(int d=1; d<DIR_SIZE; d+=2)
             {
-                //U
-                if (isValid(x-1, y) && isValid(x-2, y)
-                    && !visited[d][x-1][y])
-                {
-                    visited[d][x-1][y] = true;
-                    q.push({d, x-1, y});
-                }
+                int x = mx + dx[d];
+                int y = my + dy[d];
 
-                //D
-                if (isValid(x+1, y) && isValid(x+2, y)
-                    && !visited[d][x+1][y])
-                {
-                    visited[d][x+1][y] = true;
-                    q.push({d, x+1, y});
-                }
+                if(!isValid(x, y) || visited[isHorizontal][x][y]
+                    || !isValid(fx + dx[d], fy + dy[d]) 
+                    || !isValid(lx + dx[d], ly + dy[d]))
+                    continue;
 
-                //L
-                if (isValid(x, y-1) && isValid(x-1, y-1) && isValid(x+1, y-1)
-                    && !visited[d][x][y-1])
-                {
-                    visited[d][x][y-1] = true;
-                    q.push({d, x, y-1});
-                }
+                if(isDone({isHorizontal, x, y}, dest))
+                    return answer;
 
-                //R
-                if (isValid(x, y+1) && isValid(x-1, y+1) && isValid(x+1, y+1)
-                    && !visited[d][x][y+1])
-                {
-                    visited[d][x][y+1] = true;
-                    q.push({d, x, y+1});
-                }
-
-                //T
-                if(!visited[!d][x][y])
-                {
-                    bool flag = true;
-                    for (int i = 0; i < DIR_SIZE; ++i)
-                    {
-                        if (!isValid(x + dx[i], y + dy[i])) {
-                            flag = false;
-                            break;
-                        }
-                    }
-                    if (flag) {
-                        visited[!d][x][y] = true;
-                        q.push({!d, x, y});
-                    }
-                }
-
+                visited[isHorizontal][x][y] = true;
+                q.push({isHorizontal, x, y});
             }
-            else // 통나무가 누워져있음
+
+            // TURN
+            if(visited[!isHorizontal][mx][my]) continue;
+
+            bool flag = true;
+            for (int d=0; d<DIR_SIZE; ++d)
             {
-                //U
-                if (isValid(x-1, y-1) && isValid(x-1, y) && isValid(x-1, y+1)
-                    && !visited[d][x-1][y])
+                if (!isValid(mx + dx[d], my + dy[d]))
                 {
-                    visited[d][x-1][y] = true;
-                    q.push({d, x-1, y});
+                    flag = false;
+                    break;
                 }
+            }
 
-                //D
-                if (isValid(x+1, y-1) && isValid(x+1, y) && isValid(x+1, y+1)
-                    && !visited[d][x+1][y])
-                {
-                    visited[d][x+1][y] = true;
-                    q.push({d, x+1, y});
-                }
-
-                //L
-                if (isValid(x, y-1) && isValid(x, y-2)
-                    && !visited[d][x][y-1])
-                {
-                    visited[d][x][y-1] = true;
-                    q.push({d, x, y-1});
-                }
-
-                //R
-                if (isValid(x, y+1) && isValid(x, y+2)
-                    && !visited[d][x][y+1])
-                {
-                    visited[d][x][y+1] = true;
-                    q.push({d, x, y+1});
-                }
-
-                //T
-                if(!visited[!d][x][y])
-                {
-                    bool flag = true;
-                    for (int i = 0; i < DIR_SIZE; ++i)
-                    {
-                        if (!isValid(x + dx[i], y + dy[i])) {
-                            flag = false;
-                            break;
-                        }
-                    }
-                    if (flag) {
-                        visited[!d][x][y] = true;
-                        q.push({!d, x, y});
-                    }
-                }
+            if (flag)
+            {
+                visited[!isHorizontal][mx][my] = true;
+                q.push({!isHorizontal, mx, my});
             }
         }
-        ++answer;
     }
 
     return 0;
@@ -171,6 +102,9 @@ int bfs()
 
 int main()
 {
+    std::ios_base::sync_with_stdio(false);
+    std::cin.tie(NULL);
+
     std::cin >> N;
 
     char ch;

--- a/u1qns/Week_25/BOJ_1938_통나무옮기기.cpp
+++ b/u1qns/Week_25/BOJ_1938_통나무옮기기.cpp
@@ -1,0 +1,194 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#define MAX 51
+#define DIR_SIZE 9
+typedef std::pair<int, int> pii;
+
+const int dx[DIR_SIZE] = {-1, -1, -1, 0, 0, 0, 1, 1, 1};
+const int dy[DIR_SIZE] = {-1, 0, 1, -1, 0, 1, -1, 0, 1};
+
+int N;
+bool grid[MAX][MAX] = {false, };
+
+bool isValid(const int x, const int y)
+{
+    if(x < 0 || y < 0 || x >= N || y >= N || grid[x][y])
+      return false;
+    return true;
+}
+
+std::vector<pii> start, end;
+struct Node
+{
+    Node() = default;
+    Node(int d, int x, int y) : d(d), x(x), y(y) {}
+    int d, x, y;
+};
+
+bool isDone(const Node& target, const Node& dest)
+{
+    return (dest.d == target.d
+            && dest.x == target.x
+            && dest.y == target.y);
+}
+
+int bfs()
+{
+    int answer = 0;
+    Node dest = {(end[0].first == end[1].first), end[1].first, end[1].second};
+
+    std::queue<Node> q; // 통나무의 가로 세로 여부와 통나무 중앙 위치를 중심으로 저장
+    q.push({(start[0].first == start[1].first), start[1].first, start[1].second});
+
+    bool visited[2][MAX][MAX] = {false, };
+    visited[q.front().d][q.front().x][q.front().y] = true;
+
+    while(!q.empty())
+    {
+        int qSize = q.size();
+        while(qSize--)
+        {
+            const int d = q.front().d;
+            const int x = q.front().x;
+            const int y = q.front().y;
+
+            if(isDone(q.front(), dest))
+                return answer;
+
+            q.pop();
+
+            if (!d) // 통나무가 세워져있음
+            {
+                //U
+                if (isValid(x-1, y) && isValid(x-2, y)
+                    && !visited[d][x-1][y])
+                {
+                    visited[d][x-1][y] = true;
+                    q.push({d, x-1, y});
+                }
+
+                //D
+                if (isValid(x+1, y) && isValid(x+2, y)
+                    && !visited[d][x+1][y])
+                {
+                    visited[d][x+1][y] = true;
+                    q.push({d, x+1, y});
+                }
+
+                //L
+                if (isValid(x, y-1) && isValid(x-1, y-1) && isValid(x+1, y-1)
+                    && !visited[d][x][y-1])
+                {
+                    visited[d][x][y-1] = true;
+                    q.push({d, x, y-1});
+                }
+
+                //R
+                if (isValid(x, y+1) && isValid(x-1, y+1) && isValid(x+1, y+1)
+                    && !visited[d][x][y+1])
+                {
+                    visited[d][x][y+1] = true;
+                    q.push({d, x, y+1});
+                }
+
+                //T
+                if(!visited[!d][x][y])
+                {
+                    bool flag = true;
+                    for (int i = 0; i < DIR_SIZE; ++i)
+                    {
+                        if (!isValid(x + dx[i], y + dy[i])) {
+                            flag = false;
+                            break;
+                        }
+                    }
+                    if (flag) {
+                        visited[!d][x][y] = true;
+                        q.push({!d, x, y});
+                    }
+                }
+
+            }
+            else // 통나무가 누워져있음
+            {
+                //U
+                if (isValid(x-1, y-1) && isValid(x-1, y) && isValid(x-1, y+1)
+                    && !visited[d][x-1][y])
+                {
+                    visited[d][x-1][y] = true;
+                    q.push({d, x-1, y});
+                }
+
+                //D
+                if (isValid(x+1, y-1) && isValid(x+1, y) && isValid(x+1, y+1)
+                    && !visited[d][x+1][y])
+                {
+                    visited[d][x+1][y] = true;
+                    q.push({d, x+1, y});
+                }
+
+                //L
+                if (isValid(x, y-1) && isValid(x, y-2)
+                    && !visited[d][x][y-1])
+                {
+                    visited[d][x][y-1] = true;
+                    q.push({d, x, y-1});
+                }
+
+                //R
+                if (isValid(x, y+1) && isValid(x, y+2)
+                    && !visited[d][x][y+1])
+                {
+                    visited[d][x][y+1] = true;
+                    q.push({d, x, y+1});
+                }
+
+                //T
+                if(!visited[!d][x][y])
+                {
+                    bool flag = true;
+                    for (int i = 0; i < DIR_SIZE; ++i)
+                    {
+                        if (!isValid(x + dx[i], y + dy[i])) {
+                            flag = false;
+                            break;
+                        }
+                    }
+                    if (flag) {
+                        visited[!d][x][y] = true;
+                        q.push({!d, x, y});
+                    }
+                }
+            }
+        }
+        ++answer;
+    }
+
+    return 0;
+}
+
+
+int main()
+{
+    std::cin >> N;
+
+    char ch;
+    for(int i=0; i<N; ++i)
+    {
+        for(int j=0; j<N; ++j)
+        {
+            std::cin >> ch;
+            grid[i][j] = (ch=='1');
+
+            if(ch == 'B')
+                start.push_back({i, j});
+            else if(ch=='E')
+                end.push_back({i, j});
+        }
+    }
+
+    std::cout << bfs();
+
+    return 0;
+}


### PR DESCRIPTION
## 이슈넘버
#702

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/80731964)

## 소요시간
120분

## 알고리즘
BFS, 구현

## 풀이
문제를 읽으며 "가중치가 없는 최단 경로"구하기라는 것을 알았고 BFS로 알고리즘을 특정했다.
일단 3개의 칸을 차지하는 통나무 중 하나의 위치를 기준으로 잡아주었다. 

BFS의 재방문 방지를 위한 특정값이 필요하기 때문에 나는 중간에 있는 위치를 기준으로 잡았다. 
회전을 할 때 중심을 기준으로 8방 탐색을 하면 쉽기 떄문이다!

그리고 재방문체크는 `3차원 배열`을 이용해준다. 
```
bool visited[가로니?][x][y]
```
같은 좌표라고 하더라도 통나무의 방향이 (가로)인지 (세로)인지에 따라서 갈 수 있는 방향이 달라지기 떄문에 구별이 필요하다. 


---
현재는 문제를 풀기 위해 노가다를 했는데 생각해보니 그냥 for문으로 어찌저찌 처리할 수 있을 것 같다. 
대신 통나무의 위치를 모두 데리고 다녀야하지 않을까? .. 

-> @ys4512558 님의 코드를 보고 리팩토링 완료 ! 