### PR TITLE
[240717] BOJ 15553 난로

### DIFF
--- a/u1qns/Week_26/BOJ_15553_난로.cpp
+++ b/u1qns/Week_26/BOJ_15553_난로.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <queue>
+
+int start, end;
+
+int main()
+{
+
+    std::priority_queue<int> pq;
+
+    int N, K;
+    int answer = 0;
+    std::cin >> N >> K;
+    std::cin >> start;
+
+    int pre = start, tmp;
+    for (int i=1; i<N; ++i)
+    {
+        std::cin >> tmp;
+        pq.push(tmp- pre-1);
+        pre = tmp;
+    }
+
+    end = pre;
+    answer = end+1 - start; // 전체 시간 (마지막으로 나간 시간 - 처음 들어온 시간)
+
+    while (--K)
+    {
+        answer -= pq.top();
+        pq.pop();
+    }
+
+    std::cout << answer;
+
+    return 0;
+}


### PR DESCRIPTION
## 이슈넘버
#731 

## 소스코드
```cpp
#include <iostream>
#include <queue>

int main()
{
    int N, K, answer = 0;
    int start, end, pre, tmp;

    std::cin >> N >> K >> start;


    pre = start;
    std::priority_queue<int> pq;

    for (int i=1; i<N; ++i)
    {
        std::cin >> tmp;
        pq.push(tmp- pre-1);
        pre = tmp;
    }

    end = pre;
    answer = end+1 - start; // 전체 시간 (마지막으로 나간 시간 - 처음 들어온 시간)

    while (--K)
    {
        answer -= pq.top();
        pq.pop();
    }

    std::cout << answer;

    return 0;
}
```

## 소요시간
20분

## 알고리즘
그리디


## 풀이
- 친구가 들어오는 순서가 겹치지 않고 오름차순으로 입력이 들어온다. 
- 상식적으로 A친구가 오고 나서  B친구가 올때 갭이 크다면 ? 최대한 A친구가 나가고 바로 끄는게 이득이다. 
- A,B친구가 다녀갔을 때 소모량 : B친구가 나간 시간  - A친구가 들어온 시간 이기때문에 이를 pq에 넣는다. 그럼 갭이 큰 것들이 상단에 올라오기 때문에 k개를 제외해준다. 그 나머지는 그냥 쭉 난로를 켜줘야하기 때문에 이런 알고리즘이 정상 작동하게 된다. 