### PR TITLE
[240729] BOJ 2470 두 용액

### DIFF
--- a/trankill1127/w28/BOJ_2470.java
+++ b/trankill1127/w28/BOJ_2470.java
@@ -1,0 +1,49 @@
+package trankill1127.w28;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_2470 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine().trim());
+
+		int[] arr = new int[n];
+		StringTokenizer st = new StringTokenizer(br.readLine().trim());
+		for (int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+
+		int l = 0;
+		int r = n - 1;
+		int minAbs = Integer.MAX_VALUE;
+		int[] result = new int[2];
+
+		while (l < r) {
+			int sum = arr[l] + arr[r];
+			int absSum = Math.abs(sum);
+
+			if (absSum < minAbs) {
+				minAbs = absSum;
+				result[0] = arr[l];
+				result[1] = arr[r];
+				if (sum == 0)
+					break;
+			}
+
+			if (sum > 0)
+				r--;
+			else
+				l++;
+		}
+
+		StringBuilder sb = new StringBuilder();
+		sb.append(result[0]).append(' ').append(result[1]);
+		System.out.print(sb);
+	}
+}
+
+
+


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#771 

## 소스코드
```
import java.io.*;
import java.util.*;

public class Main {
    public static void main(String[] args) throws IOException {
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        int n = Integer.parseInt(br.readLine().trim());
        
        int[] arr = new int[n];
        StringTokenizer st = new StringTokenizer(br.readLine().trim());
        for (int i = 0; i < n; i++) {
            arr[i] = Integer.parseInt(st.nextToken());
        }
        Arrays.sort(arr);
        
        int l = 0;
        int r = n - 1;
        int minAbs = Integer.MAX_VALUE;
        int[] result = new int[2];
        
        while (l < r) {
            int sum = arr[l] + arr[r];
            int absSum = Math.abs(sum);
            
            if (absSum < minAbs) {
                minAbs = absSum;
                result[0] = arr[l];
                result[1] = arr[r];
                if (sum == 0) break; 
            }
            
            if (sum > 0) r--;
            else l++;
        }
        
        StringBuilder sb = new StringBuilder();
        sb.append(result[0]).append(' ').append(result[1]);
        System.out.print(sb);
    }
}
```

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
1시간 15분

## 알고리즘
<!---- 문제 풀이에 사용된 알고리즘을 작성해 주세요 -->
투 포인터

## 풀이
<!---- 여기서부터는 자유롭게 작성하시면 됩니다.-->

일단 정렬이 안되어 있으면 불편하기 때문에 무조건 정렬을 해야 한다고 생각했다.

처음에 정렬했던 방식은 절대값 기준 내림차순이었다.
이러면 절대값이 같으면서 부호가 다른 애들이 양 옆에 있으니까 더 빨리 알 수 있지 않을까 했는데... 그렇게 풀었더니 1퍼 틀이 떴다.

그래서 정렬 방식을 그냥 오른차순으로 바꿨다.
그리고 양 끝에 각각 포인터를  지정하고 |두 값의 sum|과 minSum을 비교해서 더 작은 값인지 확인하고 두 용액을 결정하는 방식으로 수정했고 문제 없이 통과할 수 있었다.