### PR TITLE
[240802] BOJ 1743 음식물 피하기

### DIFF
--- a/trankill1127/w28/BOJ_1743.java
+++ b/trankill1127/w28/BOJ_1743.java
@@ -1,0 +1,64 @@
+package trankill1127.w28;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_1743 {
+	public static int[][] dir = {
+		{-1,0}, {1,0}, {0,1}, {0,-1}
+	};
+	public static int n;
+	public static int m;
+	public static boolean[][] map;
+	public static boolean[][] visited;
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine().trim());
+		n=Integer.parseInt(st.nextToken());
+		m=Integer.parseInt(st.nextToken());
+		int k=Integer.parseInt(st.nextToken());
+		map = new boolean[n+2][m+2];
+		visited = new boolean[n+1][m+1];
+		List<int[]> points = new ArrayList<>();
+		for (int i=0; i<k; i++){
+			st = new StringTokenizer(br.readLine().trim());
+			int x=Integer.parseInt(st.nextToken());
+			int y=Integer.parseInt(st.nextToken());
+			points.add(new int[]{x,y});
+			map[x][y]=true;
+		}
+
+		int maxSize=0;
+		for (int[] now: points){
+			if (visited[now[0]][now[1]]) continue;
+			maxSize=Math.max(maxSize, solution(now[0], now[1]));
+		}
+		System.out.println(maxSize);
+	}
+
+	public static int solution(int x, int y){
+		Queue<int[]> q = new LinkedList<>();
+		q.add(new int[]{x,y});
+		visited[x][y]=true;
+
+		int totCnt=0;
+		while(!q.isEmpty()){
+			int cnt=q.size();
+			totCnt+=cnt;
+
+			while(cnt-->0){
+				int[] now = q.poll();
+				for (int i=0; i<4; i++){
+					int nx=now[0]+dir[i][0];
+					int ny=now[1]+dir[i][1];
+					if (!map[nx][ny] || visited[nx][ny]) continue;
+					q.add(new int[]{nx,ny});
+					visited[nx][ny]=true;
+				}
+			}
+		}
+
+		return totCnt;
+	}
+}


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#784 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/81969109)

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
40분

## 알고리즘
<!---- 문제 풀이에 사용된 알고리즘을 작성해 주세요 -->
BFS

## 풀이
<!---- 여기서부터는 자유롭게 작성하시면 됩니다.-->

`음식물들은 근처에 있는 것끼리 뭉치게 돼서 큰 음식물 쓰레기가 된다.`
`음식물 중 가장 큰 음식물의 크기를 출력하라.`

이 문장들로 BFS를 사용해야겠다고 결정할 수 있었다.

음식물의 위치에 쉽게 접근하기 위한 map 배열과 음식물이 이미 합쳐졌는지 체크하기 위한 visited 배열을 만들었다. 이후 map을 전부 다 탐색하면서 음식물이 놓인 좌표를 확인하고 이 좌표를 시작점으로 BFS를 돌리면 된다. q에 들어오는 모든 좌표의 개수가 곧 음식물 쓰레기의 크기라고 할 수 있는데, 나는 깊이에 따라 size를 구하고 그것을 totSize에 더하는 방식으로 구했다.

BFS의 시작점을 찾을 때 map 배열을 전부 다 탐색하는 방식으로 구현했는데 처음에 입력받은 k개의 봐표의 위치를 따로 ArrayList에 저장해두고 순회하는 방식으로 수정했다. 이렇게 하면 이전에 최대 10000번 검사해야 했는데 수정하면 최대 k번이기 때문에 116ms에서 100ms로 시간을 단축할 수 있었다.