### PR TITLE
[240805] BOJ 10424 알고리즘 기말고사

### DIFF
--- a/trankill1127/w29/BOJ_10424.java
+++ b/trankill1127/w29/BOJ_10424.java
@@ -1,0 +1,30 @@
+package trankill1127.w29;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_10424 {
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n=Integer.parseInt(br.readLine().trim());
+		StringTokenizer st = new StringTokenizer(br.readLine().trim());
+
+		List<int[]> list = new ArrayList<>();
+		for (int i=0; i<n; i++){
+			list.add(new int[]{Integer.parseInt(st.nextToken()), i});
+		}
+
+		Collections.sort(list, new Comparator<int[]>(){
+			@Override
+			public int compare(int[] o1, int[] o2){
+				return o1[0]-o2[0];
+			}
+		});
+
+		StringBuilder sb = new StringBuilder("");
+		for (int i=0; i<n; i++){
+			sb.append(i-list.get(i)[1]).append("\n");
+		}
+		System.out.println(sb.toString());
+	}
+}


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#791 

## 소스코드
[클릭하면 백준 코드로 이동됩니다.](https://www.acmicpc.net/source/82082563)

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
30분

## 알고리즘
<!---- 문제 풀이에 사용된 알고리즘을 작성해 주세요 ->
정렬

## 풀이
<!---- 여기서부터는 자유롭게 작성하시면 됩니다.-->

입력을 뭘 받는 것인지부터 이해하기 어려울 수 있는데 그냥 기말고사 등수 순대로 중간고사 등수를 입력해줄테니까
중간고사 등수 기준으로 1등부터 N등의 기말고사 성적 만족도를 출력하라는 거다.

`5 4 3 2 1`의 경우를 예로 들면 아래와 같다.
- idx=0인 학생은 기말고사는 1등, 중간고사는 5등
- idx=1인 학생은 기말고사는 2등, 중간고사는 4등
- idx=2인 학생은 기말고사는 3등, 중간고사는 3등
- idx=3인 학생은 기말고사는 4등, 중간고사는 2등
- idx=4인 학생은 기말고사는 5등, 중간고사는 1등

`기말고사의 만족도` = 
`중간고사는 나보다 잘 봤는데 기말고사는 나보다 못 본 학생의 수` -
`중간고사는 나보다 못 봤는데 기말고사는 나보다 잘 본 학생의 수`

솔직히 나도 저 식은 이해 못했다... 
설명 보니까 인덱스만 따지면 되는 것 같아서 중간고사 등수 기준 오름차순으로 정렬하고 이렇게 해서 바뀐 인덱스에 원래 인덱스를 뺀 것을 출력해줬더니 맞을 수 있었다.

처음에는 일일히 모든 학생의 만족도를 출력하게 했더니 시간이 1480ms가 나왔다. 
최대 100,000번 출력 연산이 발생할 수 있기 때문인 것 같아서 최적화를 위해 StringBuilder를 이용해서 한번에 출력하는 방식으로 수정했다. 그 결과 시간을 468ms까지 줄일 수 있었다🎉