### PR TITLE
[240909] BOJ 11403 경로 찾기

### DIFF
--- a/ys4512558/Week_34/BOJ_11403_경로찾기/BOJ_11403_경로찾기.java
+++ b/ys4512558/Week_34/BOJ_11403_경로찾기/BOJ_11403_경로찾기.java
@@ -1,0 +1,40 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ11403 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+   
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+
+        int map[][] = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        for (int k = 0; k < N; k++) {
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (map[i][k] == 1 && map[k][j] == 1) {
+                        map[i][j] = 1;
+                    }
+                }
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                sb.append(map[i][j]+" ");
+            }
+            sb.append("\n");
+        }
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+    }
+}

--- a/ys4512558/Week_34/BOJ_11403_경로찾기/BOJ_11403_경로찾기.md
+++ b/ys4512558/Week_34/BOJ_11403_경로찾기/BOJ_11403_경로찾기.md
@@ -1,0 +1,64 @@
+# 소스코드
+
+```Java
+import java.io.*;
+import java.util.*;
+
+public class BOJ11403 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+
+        int map[][] = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        for (int k = 0; k < N; k++) {
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (map[i][k] == 1 && map[k][j] == 1) {
+                        map[i][j] = 1;
+                    }
+                }
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                sb.append(map[i][j]+" ");
+            }
+            sb.append("\n");
+        }
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+    }
+}
+
+```
+
+# 소요시간
+
+20분
+
+# 알고리즘
+
+> 플로이드 워셜
+
+# 풀이
+
+# BOJ 11403 경로 찾기
+
+1. 현재 인접행렬은 직접경로만을 포함하고 있다.
+2. 따라서, 해당 직접경로간의 조합을 통해 다른 정점으로 이동이 가능한 것을 모두 찾아야 한다.
+3. 이를 간단하게 플로이드 워셜을 통해 [i][k] == 1 && [k][j] == 1 를 통해 i -> j가 가능한지 확인한다.
+4. 가능하다면 [i][j] = 1로 설정해준다.
+
+---


### PR DESCRIPTION
## 이슈넘버
#831 

# 소스코드

```Java
import java.io.*;
import java.util.*;

public class BOJ11403 {
    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
    static StringBuilder sb = new StringBuilder();

    public static void main(String[] args) throws IOException {
        int N = Integer.parseInt(br.readLine());

        int map[][] = new int[N][N];

        for (int i = 0; i < N; i++) {
            StringTokenizer st = new StringTokenizer(br.readLine());
            for (int j = 0; j < N; j++) {
                map[i][j] = Integer.parseInt(st.nextToken());
            }
        }
        for (int k = 0; k < N; k++) {
            for (int i = 0; i < N; i++) {
                for (int j = 0; j < N; j++) {
                    if (map[i][k] == 1 && map[k][j] == 1) {
                        map[i][j] = 1;
                    }
                }
            }
        }

        for (int i = 0; i < N; i++) {
            for (int j = 0; j < N; j++) {
                sb.append(map[i][j]+" ");
            }
            sb.append("\n");
        }
        bw.write(sb.toString());
        bw.flush();
        bw.close();
    }
}

```

# 소요시간

20분

# 알고리즘

> 플로이드 워셜

# 풀이

# BOJ 11403 경로 찾기

1. 현재 인접행렬은 직접경로만을 포함하고 있다.
2. 따라서, 해당 직접경로간의 조합을 통해 다른 정점으로 이동이 가능한 것을 모두 찾아야 한다.
3. 이를 간단하게 플로이드 워셜을 통해 [i][k] == 1 && [k][j] == 1 를 통해 i -> j가 가능한지 확인한다.
4. 가능하다면 [i][j] = 1로 설정해준다.

---
