### PR TITLE
[241002] BOJ 15989 1, 2, 3 더하기 4

### DIFF
--- a/l-umi/Week_37/BOJ_15989_1,2,3더하기.py
+++ b/l-umi/Week_37/BOJ_15989_1,2,3더하기.py
@@ -1,0 +1,21 @@
+T = int(input())
+test_cases = [int(input()) for _ in range(T)]
+
+max_n = max(test_cases)
+
+###############################################
+dp = [1] * 10001
+# dp 테이블을 생성하고 1로 초기화 (1로만 숫자를 만드는 경우는 항상 1가지이기 때문)
+
+
+# 2를 사용해서 dp 테이블 갱신
+for i in range(2, max_n + 1):
+    dp[i] = dp[i] + dp[i - 2]
+
+# 3을 사용해서 dp 테이블 갱신
+for i in range(3, max_n + 1):
+    dp[i] = dp[i] + dp[i - 3]
+        
+###############################################
+for n in test_cases:
+    print(dp[n])


### PR DESCRIPTION
<!---- 알고리즘 문제를 해결하고, 해결 과정 작성을 위한 PR 템플릿입니다.-->
<!---- 아래의 이슈넘버, 소스코드, 소요시간, 알고리즘은 필수로 내용을 채워주세요. -->
<!---- 풀이부터는 기존 작성하시던대로 편하게 작성하시면 됩니다. -->

## 이슈넘버
<!---- 문제와 맞는 issue를 연결 해주세요. #문제제목 입력하면 이슈가 자동완성됩니다.-->
<!-- 문제 이슈는 ◎로 표기돼 있습니다. -->
#865 

## 소스코드
```python
T = int(input())
test_cases = [int(input()) for _ in range(T)]

max_n = max(test_cases)

###############################################
dp = [1] * 10001
# dp 테이블을 생성하고 1로 초기화 (1로만 숫자를 만드는 경우는 항상 1가지이기 때문)


# 2를 사용해서 dp 테이블 갱신
for i in range(2, max_n + 1):
    dp[i] = dp[i] + dp[i - 2]

# 3을 사용해서 dp 테이블 갱신
for i in range(3, max_n + 1):
    dp[i] = dp[i] + dp[i - 3]
        
###############################################
for n in test_cases:
    print(dp[n])
```

## 소요시간
<!---- 문제풀이 소요 시간을 작성해 주세요-->
30분

## 알고리즘
<!---- 문제 풀이에 사용된 알고리즘을 작성해 주세요 -->
DP

## 풀이
<!---- 여기서부터는 자유롭게 작성하시면 됩니다.-->
**점화식 dp[i] = dp[i] + dp[i - 2] + dp[i - 3]**

이 알고리즘은 DP를 사용해 n을 1, 2, 3의 합으로 만드는 경우의 수를 계산하며, dp[i]는 i를 만들 수 있는 경우의 수를 나타냅니다.
dp[i] = 1로 초기화하는 이유는 1만을 사용해서 i를 만드는 경우가 항상 1가지이기 때문입니다.
dp[i-2] + dp[i-3]로 갱신하는 이유는 i-2까지 또는 i-3까지 만든 후, 마지막에 2나 3을 더하는 경우의 수를 고려하기 위함입니다. 이를 통해 2와 3을 사용한 모든 경우의 수를 계산할 수 있습니다.


